### PR TITLE
conf: introduced (ios|android).keepalive_timeout.

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -47,13 +47,13 @@ See [SPEC.md](SPEC.md) about details for APIs.
 
 ## Android Section
 
-|name         |type  |description                                   |default|note|
-|-------------|------|----------------------------------------------|-------|----|
-|enabled      |bool  |On/Off for push notication to GCM             |true   |    |
-|apikey       |string|API key string for GCM                        |       |    |
-|timeout      |int   |timeout for push notication to GCM            |5(sec) |    |
-|keepalive_timeout|int   |time for continuing keep-alive connection to GCM  |30        |                               |
-|retry_max    |int   |maximum retry count for push notication to GCM|1      |    |
+|name             |type  |description                                     |default|note|
+|-----------------|------|------------------------------------------------|-------|----|
+|enabled          |bool  |On/Off for push notication to GCM               |true   |    |
+|apikey           |string|API key string for GCM                          |       |    |
+|timeout          |int   |timeout for push notication to GCM              |5(sec) |    |
+|keepalive_timeout|int   |time for continuing keep-alive connection to GCM|30     |    |
+|retry_max        |int   |maximum retry count for push notication to GCM  |1      |    |
 
 ## Log Section
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -40,6 +40,7 @@ See [SPEC.md](SPEC.md) about details for APIs.
 |sandbox               |bool  |On/Off for sandbox environment                        |true      |                               |
 |retry_max             |int   |maximum retry count for push notication to APNs       |1         |                               |
 |timeout               |int   |timeout for push notification to APNs                 |5         |                               |
+|keepalive_timeout     |int   |time for continuing keep-alive connection to APNs     |30        |                               |
 |topic                 |string|the assigned value of `apns-topic` for Request headers|          |                               |
 
 `topic` is mandatory when the client is connected using a certificate that supports multiple topics.
@@ -51,6 +52,7 @@ See [SPEC.md](SPEC.md) about details for APIs.
 |enabled      |bool  |On/Off for push notication to GCM             |true   |    |
 |apikey       |string|API key string for GCM                        |       |    |
 |timeout      |int   |timeout for push notication to GCM            |5(sec) |    |
+|keepalive_timeout|int   |time for continuing keep-alive connection to GCM  |30        |                               |
 |retry_max    |int   |maximum retry count for push notication to GCM|1      |    |
 
 ## Log Section

--- a/conf/gaurun.toml
+++ b/conf/gaurun.toml
@@ -15,6 +15,7 @@ config_app_uri = "/config/app"
 apikey = "apikey for GCM"
 enabled = true
 timeout = 5 # sec
+keepalive_timeout = 30
 retry_max = 0
 
 [ios]
@@ -23,6 +24,7 @@ pem_key_path = "key.pem"
 sandbox = true
 enabled = true
 timeout = 5
+keepalive_timeout = 30
 retry_max = 1
 
 [log]

--- a/gaurun/apns_http2.go
+++ b/gaurun/apns_http2.go
@@ -49,7 +49,7 @@ func NewApnsClientHttp2(certPath, keyPath string) (*http.Client, error) {
 
 	return &http.Client{
 		Transport: transport,
-		Timeout: time.Duration(ConfGaurun.Ios.Timeout) * time.Second,
+		Timeout:   time.Duration(ConfGaurun.Ios.Timeout) * time.Second,
 	}, nil
 }
 

--- a/gaurun/conf.go
+++ b/gaurun/conf.go
@@ -35,6 +35,7 @@ type SectionAndroid struct {
 	Enabled  bool   `toml:"enabled"`
 	ApiKey   string `toml:"apikey"`
 	Timeout  int    `toml:"timeout"`
+	KeepAliveTimeout int `toml:"keepalive_timeout"`
 	RetryMax int    `toml:"retry_max"`
 }
 
@@ -45,6 +46,7 @@ type SectionIos struct {
 	Sandbox     bool   `toml:"sandbox"`
 	RetryMax    int    `toml:"retry_max"`
 	Timeout     int    `toml:"timeout"`
+	KeepAliveTimeout int `toml:"keepalive_timeout"`
 	Topic       string `toml:"topic"`
 }
 
@@ -70,6 +72,7 @@ func BuildDefaultConf() ConfToml {
 	conf.Android.ApiKey = ""
 	conf.Android.Enabled = true
 	conf.Android.Timeout = 5
+	conf.Android.KeepAliveTimeout = 30
 	conf.Android.RetryMax = 1
 	// iOS
 	conf.Ios.Enabled = true
@@ -78,6 +81,7 @@ func BuildDefaultConf() ConfToml {
 	conf.Ios.Sandbox = true
 	conf.Ios.RetryMax = 1
 	conf.Ios.Timeout = 5
+	conf.Ios.KeepAliveTimeout = 30
 	conf.Ios.Topic = ""
 	// log
 	conf.Log.AccessLog = "stdout"

--- a/gaurun/conf.go
+++ b/gaurun/conf.go
@@ -32,22 +32,22 @@ type SectionApi struct {
 }
 
 type SectionAndroid struct {
-	Enabled  bool   `toml:"enabled"`
-	ApiKey   string `toml:"apikey"`
-	Timeout  int    `toml:"timeout"`
-	KeepAliveTimeout int `toml:"keepalive_timeout"`
-	RetryMax int    `toml:"retry_max"`
+	Enabled          bool   `toml:"enabled"`
+	ApiKey           string `toml:"apikey"`
+	Timeout          int    `toml:"timeout"`
+	KeepAliveTimeout int    `toml:"keepalive_timeout"`
+	RetryMax         int    `toml:"retry_max"`
 }
 
 type SectionIos struct {
-	Enabled     bool   `toml:"enabled"`
-	PemCertPath string `toml:"pem_cert_path"`
-	PemKeyPath  string `toml:"pem_key_path"`
-	Sandbox     bool   `toml:"sandbox"`
-	RetryMax    int    `toml:"retry_max"`
-	Timeout     int    `toml:"timeout"`
-	KeepAliveTimeout int `toml:"keepalive_timeout"`
-	Topic       string `toml:"topic"`
+	Enabled          bool   `toml:"enabled"`
+	PemCertPath      string `toml:"pem_cert_path"`
+	PemKeyPath       string `toml:"pem_key_path"`
+	Sandbox          bool   `toml:"sandbox"`
+	RetryMax         int    `toml:"retry_max"`
+	Timeout          int    `toml:"timeout"`
+	KeepAliveTimeout int    `toml:"keepalive_timeout"`
+	Topic            string `toml:"topic"`
 }
 
 type SectionLog struct {

--- a/gaurun/conf_test.go
+++ b/gaurun/conf_test.go
@@ -43,6 +43,7 @@ func (suite *ConfigTestSuite) TestValidateConfDefault() {
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.Enabled, true)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.ApiKey, "")
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.Timeout, 5)
+	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.KeepAliveTimeout, 30)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.RetryMax, 1)
 	// Ios
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.Enabled, true)
@@ -50,6 +51,8 @@ func (suite *ConfigTestSuite) TestValidateConfDefault() {
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.PemKeyPath, "")
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.Sandbox, true)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.RetryMax, 1)
+	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.Timeout, 5)
+	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.KeepAliveTimeout, 30)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.Topic, "")
 	// Log
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Log.AccessLog, "stdout")
@@ -72,6 +75,7 @@ func (suite *ConfigTestSuite) TestValidateConf() {
 	assert.Equal(suite.T(), suite.ConfGaurun.Android.Enabled, true)
 	assert.Equal(suite.T(), suite.ConfGaurun.Android.ApiKey, "apikey for GCM")
 	assert.Equal(suite.T(), suite.ConfGaurun.Android.Timeout, 5)
+	assert.Equal(suite.T(), suite.ConfGaurun.Android.KeepAliveTimeout, 30)
 	assert.Equal(suite.T(), suite.ConfGaurun.Android.RetryMax, 0)
 	// Ios
 	assert.Equal(suite.T(), suite.ConfGaurun.Ios.Enabled, true)
@@ -80,6 +84,7 @@ func (suite *ConfigTestSuite) TestValidateConf() {
 	assert.Equal(suite.T(), suite.ConfGaurun.Ios.Sandbox, true)
 	assert.Equal(suite.T(), suite.ConfGaurun.Ios.RetryMax, 1)
 	assert.Equal(suite.T(), suite.ConfGaurun.Ios.Timeout, 5)
+	assert.Equal(suite.T(), suite.ConfGaurun.Ios.KeepAliveTimeout, 30)
 	// Lo
 	assert.Equal(suite.T(), suite.ConfGaurun.Log.AccessLog, "stdout")
 	assert.Equal(suite.T(), suite.ConfGaurun.Log.ErrorLog, "stderr")

--- a/gaurun/global.go
+++ b/gaurun/global.go
@@ -21,5 +21,4 @@ var (
 	SeqID           uint64
 	GCMClient       *gcm.Sender
 	APNSClient      *http.Client
-	TransportGaurun *http.Transport
 )

--- a/gaurun/global.go
+++ b/gaurun/global.go
@@ -16,9 +16,9 @@ var (
 	LogError          *logrus.Logger
 	StatGaurun        StatApp
 	// for numbering push
-	OnceNumbering   sync.Once
-	WgNumbering     *sync.WaitGroup
-	SeqID           uint64
-	GCMClient       *gcm.Sender
-	APNSClient      *http.Client
+	OnceNumbering sync.Once
+	WgNumbering   *sync.WaitGroup
+	SeqID         uint64
+	GCMClient     *gcm.Sender
+	APNSClient    *http.Client
 )

--- a/gaurun/notification.go
+++ b/gaurun/notification.go
@@ -63,7 +63,7 @@ func InitHttpClient() error {
 		ApiKey: ConfGaurun.Android.ApiKey,
 		Http: &http.Client{
 			Transport: TransportGCM,
-			Timeout: time.Duration(ConfGaurun.Android.Timeout) * time.Second,
+			Timeout:   time.Duration(ConfGaurun.Android.Timeout) * time.Second,
 		},
 	}
 


### PR DESCRIPTION
This parameter controls the timeout for keep-alive connection of HTTP client.
The value is set 30 by default. (It is the default value of the `net/http` client.)