### PR TITLE
conf: introduced keepalive_conns.

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -41,6 +41,7 @@ See [SPEC.md](SPEC.md) about details for APIs.
 |retry_max             |int   |maximum retry count for push notication to APNs       |1         |                               |
 |timeout               |int   |timeout for push notification to APNs                 |5         |                               |
 |keepalive_timeout     |int   |time for continuing keep-alive connection to APNs     |30        |                               |
+|keepalive_conns       |int   |number of keep-alive connection to APNs               |runtime.NumCPU()|                         |
 |topic                 |string|the assigned value of `apns-topic` for Request headers|          |                               |
 
 `topic` is mandatory when the client is connected using a certificate that supports multiple topics.
@@ -53,6 +54,7 @@ See [SPEC.md](SPEC.md) about details for APIs.
 |apikey           |string|API key string for GCM                          |       |    |
 |timeout          |int   |timeout for push notication to GCM              |5(sec) |    |
 |keepalive_timeout|int   |time for continuing keep-alive connection to GCM|30     |    |
+|keepalive_conns  |int   |number of keep-alive connection to GCM          |runtime.NumCPU()||
 |retry_max        |int   |maximum retry count for push notication to GCM  |1      |    |
 
 ## Log Section

--- a/conf/gaurun.toml
+++ b/conf/gaurun.toml
@@ -16,6 +16,7 @@ apikey = "apikey for GCM"
 enabled = true
 timeout = 5 # sec
 keepalive_timeout = 30
+keepalive_conns = 4
 retry_max = 1
 
 [ios]
@@ -25,6 +26,7 @@ sandbox = true
 enabled = true
 timeout = 5
 keepalive_timeout = 30
+keepalive_conns = 6
 retry_max = 1
 
 [log]

--- a/gaurun/apns_http2.go
+++ b/gaurun/apns_http2.go
@@ -22,7 +22,7 @@ func NewTransportHttp2(cert tls.Certificate) (*http.Transport, error) {
 
 	transport := &http.Transport{
 		TLSClientConfig:     config,
-		MaxIdleConnsPerHost: ConfGaurun.Core.WorkerNum,
+		MaxIdleConnsPerHost: ConfGaurun.Ios.KeepAliveConns,
 		Dial: (&net.Dialer{
 			Timeout:   time.Duration(ConfGaurun.Ios.Timeout) * time.Second,
 			KeepAlive: time.Duration(ConfGaurun.Ios.KeepAliveTimeout) * time.Second,

--- a/gaurun/conf.go
+++ b/gaurun/conf.go
@@ -36,6 +36,7 @@ type SectionAndroid struct {
 	ApiKey           string `toml:"apikey"`
 	Timeout          int    `toml:"timeout"`
 	KeepAliveTimeout int    `toml:"keepalive_timeout"`
+	KeepAliveConns   int    `toml:"keepalive_conns"`
 	RetryMax         int    `toml:"retry_max"`
 }
 
@@ -47,6 +48,7 @@ type SectionIos struct {
 	RetryMax         int    `toml:"retry_max"`
 	Timeout          int    `toml:"timeout"`
 	KeepAliveTimeout int    `toml:"keepalive_timeout"`
+	KeepAliveConns   int    `toml:"keepalive_conns"`
 	Topic            string `toml:"topic"`
 }
 
@@ -73,6 +75,7 @@ func BuildDefaultConf() ConfToml {
 	conf.Android.Enabled = true
 	conf.Android.Timeout = 5
 	conf.Android.KeepAliveTimeout = 30
+	conf.Android.KeepAliveConns = conf.Core.WorkerNum
 	conf.Android.RetryMax = 1
 	// iOS
 	conf.Ios.Enabled = true
@@ -82,6 +85,7 @@ func BuildDefaultConf() ConfToml {
 	conf.Ios.RetryMax = 1
 	conf.Ios.Timeout = 5
 	conf.Ios.KeepAliveTimeout = 30
+	conf.Ios.KeepAliveConns = conf.Core.WorkerNum
 	conf.Ios.Topic = ""
 	// log
 	conf.Log.AccessLog = "stdout"

--- a/gaurun/conf.go
+++ b/gaurun/conf.go
@@ -59,10 +59,12 @@ type SectionLog struct {
 }
 
 func BuildDefaultConf() ConfToml {
+	numCPU := runtime.NumCPU()
+
 	var conf ConfToml
 	// Core
 	conf.Core.Port = "1056"
-	conf.Core.WorkerNum = runtime.NumCPU()
+	conf.Core.WorkerNum = numCPU
 	conf.Core.QueueNum = 8192
 	conf.Core.NotificationMax = 100
 	// Api
@@ -75,7 +77,7 @@ func BuildDefaultConf() ConfToml {
 	conf.Android.Enabled = true
 	conf.Android.Timeout = 5
 	conf.Android.KeepAliveTimeout = 30
-	conf.Android.KeepAliveConns = conf.Core.WorkerNum
+	conf.Android.KeepAliveConns = numCPU
 	conf.Android.RetryMax = 1
 	// iOS
 	conf.Ios.Enabled = true
@@ -85,7 +87,7 @@ func BuildDefaultConf() ConfToml {
 	conf.Ios.RetryMax = 1
 	conf.Ios.Timeout = 5
 	conf.Ios.KeepAliveTimeout = 30
-	conf.Ios.KeepAliveConns = conf.Core.WorkerNum
+	conf.Ios.KeepAliveConns = numCPU
 	conf.Ios.Topic = ""
 	// log
 	conf.Log.AccessLog = "stdout"

--- a/gaurun/conf_test.go
+++ b/gaurun/conf_test.go
@@ -21,6 +21,7 @@ type ConfigTestSuite struct {
 
 func (suite *ConfigTestSuite) SetupTest() {
 	suite.ConfGaurunDefault = BuildDefaultConf()
+	suite.ConfGaurun = BuildDefaultConf()
 	var err error
 	suite.ConfGaurun, err = LoadConf(suite.ConfGaurun, ConfGaurunPath)
 	if err != nil {
@@ -44,6 +45,7 @@ func (suite *ConfigTestSuite) TestValidateConfDefault() {
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.ApiKey, "")
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.Timeout, 5)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.KeepAliveTimeout, 30)
+	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.KeepAliveConns, suite.ConfGaurunDefault.Core.WorkerNum)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.RetryMax, 1)
 	// Ios
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.Enabled, true)
@@ -53,6 +55,7 @@ func (suite *ConfigTestSuite) TestValidateConfDefault() {
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.RetryMax, 1)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.Timeout, 5)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.KeepAliveTimeout, 30)
+	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.KeepAliveConns, suite.ConfGaurunDefault.Core.WorkerNum)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.Topic, "")
 	// Log
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Log.AccessLog, "stdout")
@@ -76,7 +79,8 @@ func (suite *ConfigTestSuite) TestValidateConf() {
 	assert.Equal(suite.T(), suite.ConfGaurun.Android.ApiKey, "apikey for GCM")
 	assert.Equal(suite.T(), suite.ConfGaurun.Android.Timeout, 5)
 	assert.Equal(suite.T(), suite.ConfGaurun.Android.KeepAliveTimeout, 30)
-	assert.Equal(suite.T(), suite.ConfGaurun.Android.RetryMax, 0)
+	assert.Equal(suite.T(), suite.ConfGaurun.Android.KeepAliveConns, 4)
+	assert.Equal(suite.T(), suite.ConfGaurun.Android.RetryMax, 1)
 	// Ios
 	assert.Equal(suite.T(), suite.ConfGaurun.Ios.Enabled, true)
 	assert.Equal(suite.T(), suite.ConfGaurun.Ios.PemCertPath, "cert.pem")
@@ -85,6 +89,7 @@ func (suite *ConfigTestSuite) TestValidateConf() {
 	assert.Equal(suite.T(), suite.ConfGaurun.Ios.RetryMax, 1)
 	assert.Equal(suite.T(), suite.ConfGaurun.Ios.Timeout, 5)
 	assert.Equal(suite.T(), suite.ConfGaurun.Ios.KeepAliveTimeout, 30)
+	assert.Equal(suite.T(), suite.ConfGaurun.Ios.KeepAliveConns, 6)
 	// Lo
 	assert.Equal(suite.T(), suite.ConfGaurun.Log.AccessLog, "stdout")
 	assert.Equal(suite.T(), suite.ConfGaurun.Log.ErrorLog, "stderr")

--- a/gaurun/notification.go
+++ b/gaurun/notification.go
@@ -53,7 +53,7 @@ type CertificatePem struct {
 
 func InitHttpClient() error {
 	TransportGCM := &http.Transport{
-		MaxIdleConnsPerHost: ConfGaurun.Core.WorkerNum,
+		MaxIdleConnsPerHost: ConfGaurun.Android.KeepAliveConns,
 		Dial: (&net.Dialer{
 			Timeout:   time.Duration(ConfGaurun.Android.Timeout) * time.Second,
 			KeepAlive: time.Duration(ConfGaurun.Android.KeepAliveTimeout) * time.Second,


### PR DESCRIPTION
Previously Gaurun keeped connections to APNs and GCM as same as the number of workers.
But it is not always efficient when the number of workers is large.