### PR TITLE
conf: introduced core.pusher_max for asynchronous pushing.

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -18,6 +18,7 @@ A configuration for Gaurun has some sections. A example is [here](conf/gaurun.to
 |workers         |int   |number of workers for push notification     |runtime.NumCPU()|`-w` options can overwrite          |
 |queues          |int   |size of internal queue for push notification|8192            |`-q` options can overwrite          |
 |notification_max|int   |limit of push notifications once            |100             |                                    |
+|pusher_max      |int64 |maximum asynchronous pushing threads        |0               |If the value is zero, each worker pushes synchronously|
 
 ## API Section
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -18,7 +18,7 @@ A configuration for Gaurun has some sections. A example is [here](conf/gaurun.to
 |workers         |int   |number of workers for push notification     |runtime.NumCPU()|`-w` options can overwrite          |
 |queues          |int   |size of internal queue for push notification|8192            |`-q` options can overwrite          |
 |notification_max|int   |limit of push notifications once            |100             |                                    |
-|pusher_max      |int64 |maximum asynchronous pushing threads        |0               |If the value is zero, each worker pushes synchronously|
+|pusher_max      |int64 |maximum goroutines for asynchronous pushing |0               |If the value is zero, each worker pushes synchronously|
 
 ## API Section
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -18,7 +18,7 @@ A configuration for Gaurun has some sections. A example is [here](conf/gaurun.to
 |workers         |int   |number of workers for push notification     |runtime.NumCPU()|`-w` options can overwrite          |
 |queues          |int   |size of internal queue for push notification|8192            |`-q` options can overwrite          |
 |notification_max|int   |limit of push notifications once            |100             |                                    |
-|pusher_max      |int64 |maximum goroutines for asynchronous pushing |0               |If the value is zero, each worker pushes synchronously|
+|pusher_max      |int64 |maximum goroutines for asynchronous pushing |0               |If the value is less than or equal to zero, each worker pushes synchronously|
 
 ## API Section
 

--- a/conf/gaurun.toml
+++ b/conf/gaurun.toml
@@ -4,6 +4,7 @@ port = "1056"
 workers = 8
 queues = 8192
 notification_max = 100
+pusher_max = 16
 
 [api]
 push_uri = "/push"

--- a/gaurun/conf.go
+++ b/gaurun/conf.go
@@ -22,6 +22,7 @@ type SectionCore struct {
 	WorkerNum       int    `toml:"workers"`
 	QueueNum        int    `toml:"queues"`
 	NotificationMax int    `toml:"notification_max"`
+	PusherMax       int64  `toml:"pusher_max"`
 }
 
 type SectionApi struct {
@@ -63,6 +64,7 @@ func BuildDefaultConf() ConfToml {
 	conf.Core.WorkerNum = runtime.NumCPU()
 	conf.Core.QueueNum = 8192
 	conf.Core.NotificationMax = 100
+	conf.Core.PusherMax = 0
 	// Api
 	conf.Api.PushUri = "/push"
 	conf.Api.StatGoUri = "/stat/go"

--- a/gaurun/conf_test.go
+++ b/gaurun/conf_test.go
@@ -34,6 +34,7 @@ func (suite *ConfigTestSuite) TestValidateConfDefault() {
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Core.WorkerNum, runtime.NumCPU())
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Core.QueueNum, 8192)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Core.NotificationMax, 100)
+	assert.Equal(suite.T(), suite.ConfGaurunDefault.Core.PusherMax, int64(0))
 	// API
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Api.PushUri, "/push")
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Api.StatGoUri, "/stat/go")
@@ -65,7 +66,8 @@ func (suite *ConfigTestSuite) TestValidateConf() {
 	assert.Equal(suite.T(), suite.ConfGaurun.Core.Port, "1056")
 	assert.Equal(suite.T(), suite.ConfGaurun.Core.WorkerNum, 8)
 	assert.Equal(suite.T(), suite.ConfGaurun.Core.QueueNum, 8192)
-	assert.Equal(suite.T(), suite.ConfGaurunDefault.Core.NotificationMax, 100)
+	assert.Equal(suite.T(), suite.ConfGaurun.Core.NotificationMax, 100)
+	assert.Equal(suite.T(), suite.ConfGaurun.Core.PusherMax, int64(16))
 	// API
 	assert.Equal(suite.T(), suite.ConfGaurun.Api.PushUri, "/push")
 	assert.Equal(suite.T(), suite.ConfGaurun.Api.StatGoUri, "/stat/go")
@@ -85,7 +87,7 @@ func (suite *ConfigTestSuite) TestValidateConf() {
 	assert.Equal(suite.T(), suite.ConfGaurun.Ios.RetryMax, 1)
 	assert.Equal(suite.T(), suite.ConfGaurun.Ios.Timeout, 5)
 	assert.Equal(suite.T(), suite.ConfGaurun.Ios.KeepAliveTimeout, 30)
-	// Lo
+	// Log
 	assert.Equal(suite.T(), suite.ConfGaurun.Log.AccessLog, "stdout")
 	assert.Equal(suite.T(), suite.ConfGaurun.Log.ErrorLog, "stderr")
 	assert.Equal(suite.T(), suite.ConfGaurun.Log.Level, "error")

--- a/gaurun/stat.go
+++ b/gaurun/stat.go
@@ -8,12 +8,12 @@ import (
 )
 
 type StatApp struct {
-	QueueMax   int         `json:"queue_max"`
-	QueueUsage int         `json:"queue_usage"`
-	PusherMax  int64       `json:"pusher_max"`
-	PusherCount int64      `json:"pusher_count"`
-	Ios        StatIos     `json:"ios"`
-	Android    StatAndroid `json:"android"`
+	QueueMax    int         `json:"queue_max"`
+	QueueUsage  int         `json:"queue_usage"`
+	PusherMax   int64       `json:"pusher_max"`
+	PusherCount int64       `json:"pusher_count"`
+	Ios         StatIos     `json:"ios"`
+	Android     StatAndroid `json:"android"`
 }
 
 type StatAndroid struct {

--- a/gaurun/stat.go
+++ b/gaurun/stat.go
@@ -10,6 +10,8 @@ import (
 type StatApp struct {
 	QueueMax   int         `json:"queue_max"`
 	QueueUsage int         `json:"queue_usage"`
+	PusherMax  int64       `json:"pusher_max"`
+	PusherCount int64      `json:"pusher_count"`
 	Ios        StatIos     `json:"ios"`
 	Android    StatAndroid `json:"android"`
 }
@@ -26,6 +28,7 @@ type StatIos struct {
 
 func InitStat() {
 	StatGaurun.QueueUsage = 0
+	StatGaurun.PusherCount = 0
 	StatGaurun.Ios.PushSuccess = 0
 	StatGaurun.Ios.PushError = 0
 	StatGaurun.Android.PushSuccess = 0
@@ -36,6 +39,8 @@ func StatsHandler(w http.ResponseWriter, r *http.Request) {
 	var result StatApp
 	result.QueueMax = cap(QueueNotification)
 	result.QueueUsage = len(QueueNotification)
+	result.PusherMax = ConfGaurun.Core.PusherMax
+	result.PusherCount = atomic.LoadInt64(&PusherCount)
 	result.Ios.PushSuccess = atomic.LoadInt64(&StatGaurun.Ios.PushSuccess)
 	result.Ios.PushError = atomic.LoadInt64(&StatGaurun.Ios.PushError)
 	result.Android.PushSuccess = atomic.LoadInt64(&StatGaurun.Android.PushSuccess)

--- a/gaurun/worker.go
+++ b/gaurun/worker.go
@@ -3,7 +3,16 @@ package gaurun
 import (
 	"github.com/RobotsAndPencils/buford/push"
 	"strings"
+	"sync/atomic"
 )
+
+var (
+	PusherCount int64
+)
+
+func init() {
+	PusherCount = 0
+}
 
 func StartPushWorkers(workerNum, queueNum int) {
 	QueueNotification = make(chan RequestGaurunNotification, queueNum)
@@ -12,44 +21,76 @@ func StartPushWorkers(workerNum, queueNum int) {
 	}
 }
 
+func isExternalServerError(err error, platform int) bool {
+	switch platform {
+	case PlatFormIos:
+		if err == push.ErrIdleTimeout || err == push.ErrShutdown || err == push.ErrInternalServerError || err == push.ErrServiceUnavailable {
+			return true
+		}
+	case PlatFormAndroid:
+		if err.Error() == "Unavailable" || err.Error() == "InternalServerError" || strings.Contains(err.Error(), "Timeout") {
+			return true
+		}
+	default:
+		// not through
+	}
+	return false
+}
+
+func pushSync(pusher func(req RequestGaurunNotification) error, req RequestGaurunNotification, retryMax int) {
+Retry:
+	err := pusher(req)
+	if err != nil && req.Retry < retryMax && isExternalServerError(err, req.Platform) {
+		req.Retry++
+		goto Retry
+	}
+}
+
+func pushAsync(pusher func(req RequestGaurunNotification) error, req RequestGaurunNotification, retryMax int) {
+	atomic.AddInt64(&PusherCount, 1)
+
+Retry:
+	err := pusher(req)
+	if err != nil && req.Retry < retryMax && isExternalServerError(err, req.Platform) {
+		req.Retry++
+		goto Retry
+	}
+
+	atomic.AddInt64(&PusherCount, -1)
+}
+
 func pushNotificationWorker() {
 	var (
-		err      error
-		retryMax int
+		retryMax  int
+		pusher    func(req RequestGaurunNotification) error
+		pusherMax int64
 	)
+
+	pusherMax = ConfGaurun.Core.PusherMax
 
 	for {
 		notification := <-QueueNotification
-	Retry:
+
 		switch notification.Platform {
 		case PlatFormIos:
-			err = pushNotificationIos(notification)
+			pusher = pushNotificationIos
 			retryMax = ConfGaurun.Ios.RetryMax
 		case PlatFormAndroid:
-			err = pushNotificationAndroid(notification)
+			pusher = pushNotificationAndroid
 			retryMax = ConfGaurun.Android.RetryMax
 		default:
 			LogError.Warnf("invalid platform: %d", notification.Platform)
 			continue
 		}
-		// retry when server error is occurred.
-		if err != nil && notification.Retry < retryMax {
-			switch notification.Platform {
-			case PlatFormIos:
-				if err == push.ErrIdleTimeout || err == push.ErrShutdown || err == push.ErrInternalServerError || err == push.ErrServiceUnavailable {
-					notification.Retry++
-					goto Retry
-				}
-			case PlatFormAndroid:
-				if err.Error() == "Unavailable" || err.Error() == "InternalServerError" || strings.Contains(err.Error(), "Timeout") {
-					notification.Retry++
-					goto Retry
-				}
-			default:
-				// not through
-				continue
-			}
 
+		if pusherMax == 0 {
+			pushSync(pusher, notification, retryMax)
+			continue
+		}
+
+		if atomic.LoadInt64(&PusherCount) < pusherMax {
+			go pushAsync(pusher, notification, retryMax)
+			continue
 		}
 	}
 }

--- a/gaurun/worker.go
+++ b/gaurun/worker.go
@@ -91,6 +91,9 @@ func pushNotificationWorker() {
 		if atomic.LoadInt64(&PusherCount) < pusherMax {
 			go pushAsync(pusher, notification, retryMax)
 			continue
+		} else {
+			pushSync(pusher, notification, retryMax)
+			continue
 		}
 	}
 }

--- a/gaurun/worker.go
+++ b/gaurun/worker.go
@@ -83,7 +83,7 @@ func pushNotificationWorker() {
 			continue
 		}
 
-		if pusherMax == 0 {
+		if pusherMax <= 0 {
 			pushSync(pusher, notification, retryMax)
 			continue
 		}

--- a/gaurun/worker.go
+++ b/gaurun/worker.go
@@ -47,8 +47,6 @@ Retry:
 }
 
 func pushAsync(pusher func(req RequestGaurunNotification) error, req RequestGaurunNotification, retryMax int) {
-	atomic.AddInt64(&PusherCount, 1)
-
 Retry:
 	err := pusher(req)
 	if err != nil && req.Retry < retryMax && isExternalServerError(err, req.Platform) {
@@ -89,6 +87,7 @@ func pushNotificationWorker() {
 		}
 
 		if atomic.LoadInt64(&PusherCount) < pusherMax {
+			atomic.AddInt64(&PusherCount, 1)
 			go pushAsync(pusher, notification, retryMax)
 			continue
 		} else {


### PR DESCRIPTION
In terms of the client, Gaurun pushes asynchronously. But in terms of internal, previously Gaurun's each worker pushed synchronously.

This implementation allows that Gaurun's each worker pushes asynchronously until the number of goroutine for pushing reaches `core.pusher_max`.

If `core.pusher_max` is less than or equal to zero or the number of goroutine for pushing reaches `core.pusher_max`, Gaurun's each worker pushes synchronously.