### PR TITLE
core: changed type for core parameters.

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -14,9 +14,9 @@ The configuration for Gaurun has some sections. The example is [here](conf/gauru
 |name            |type  |description                                 |default         |note                                |
 |----------------|------|--------------------------------------------|----------------|------------------------------------|
 |port            |string|port number or unix socket path             |1056            |e.g.)1056, unix:/tmp/gaurun.sock <br/> `-p` option can overwrite    |
-|workers         |int   |number of workers for push notification     |runtime.NumCPU()|`-w` options can overwrite          |
-|queues          |int   |size of internal queue for push notification|8192            |`-q` options can overwrite          |
-|notification_max|int   |limit of push notifications once            |100             |                                    |
+|workers         |int64 |number of workers for push notification     |runtime.NumCPU()|`-w` options can overwrite          |
+|queues          |int64 |size of internal queue for push notification|8192            |`-q` options can overwrite          |
+|notification_max|int64 |limit of push notifications once            |100             |                                    |
 |pusher_max      |int64 |maximum goroutines for asynchronous pushing |0               |If the value is less than or equal to zero, each worker pushes synchronously|
 
 ## iOS Section

--- a/cmd/gaurun/gaurun.go
+++ b/cmd/gaurun/gaurun.go
@@ -13,8 +13,8 @@ func main() {
 	versionPrinted := flag.Bool("v", false, "gaurun version")
 	confPath := flag.String("c", "", "configuration file path for gaurun")
 	listenPort := flag.String("p", "", "port number or unix socket path")
-	workerNum := flag.Int("w", 0, "number of workers for push notification")
-	queueNum := flag.Int("q", 0, "size of internal queue for push notification")
+	workerNum := flag.Int64("w", 0, "number of workers for push notification")
+	queueNum := flag.Int64("q", 0, "size of internal queue for push notification")
 	flag.Parse()
 
 	if *versionPrinted {

--- a/gaurun/conf.go
+++ b/gaurun/conf.go
@@ -21,9 +21,9 @@ type ConfToml struct {
 
 type SectionCore struct {
 	Port            string `toml:"port"`
-	WorkerNum       int    `toml:"workers"`
-	QueueNum        int    `toml:"queues"`
-	NotificationMax int    `toml:"notification_max"`
+	WorkerNum       int64  `toml:"workers"`
+	QueueNum        int64  `toml:"queues"`
+	NotificationMax int64  `toml:"notification_max"`
 	PusherMax       int64  `toml:"pusher_max"`
 }
 
@@ -60,7 +60,7 @@ func BuildDefaultConf() ConfToml {
 	var conf ConfToml
 	// Core
 	conf.Core.Port = "1056"
-	conf.Core.WorkerNum = numCPU
+	conf.Core.WorkerNum = int64(numCPU)
 	conf.Core.QueueNum = 8192
 	conf.Core.NotificationMax = 100
 	conf.Core.PusherMax = 0

--- a/gaurun/conf_test.go
+++ b/gaurun/conf_test.go
@@ -32,16 +32,16 @@ func (suite *ConfigTestSuite) SetupTest() {
 func (suite *ConfigTestSuite) TestValidateConfDefault() {
 	// Core
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Core.Port, "1056")
-	assert.Equal(suite.T(), suite.ConfGaurunDefault.Core.WorkerNum, runtime.NumCPU())
-	assert.Equal(suite.T(), suite.ConfGaurunDefault.Core.QueueNum, 8192)
-	assert.Equal(suite.T(), suite.ConfGaurunDefault.Core.NotificationMax, 100)
+	assert.Equal(suite.T(), suite.ConfGaurunDefault.Core.WorkerNum, int64(runtime.NumCPU()))
+	assert.Equal(suite.T(), suite.ConfGaurunDefault.Core.QueueNum, int64(8192))
+	assert.Equal(suite.T(), suite.ConfGaurunDefault.Core.NotificationMax, int64(100))
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Core.PusherMax, int64(0))
 	// Android
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.Enabled, true)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.ApiKey, "")
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.Timeout, 5)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.KeepAliveTimeout, 30)
-	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.KeepAliveConns, suite.ConfGaurunDefault.Core.WorkerNum)
+	assert.Equal(suite.T(), int64(suite.ConfGaurunDefault.Android.KeepAliveConns), suite.ConfGaurunDefault.Core.WorkerNum)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.RetryMax, 1)
 	// Ios
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.Enabled, true)
@@ -51,7 +51,7 @@ func (suite *ConfigTestSuite) TestValidateConfDefault() {
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.RetryMax, 1)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.Timeout, 5)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.KeepAliveTimeout, 30)
-	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.KeepAliveConns, suite.ConfGaurunDefault.Core.WorkerNum)
+	assert.Equal(suite.T(), int64(suite.ConfGaurunDefault.Ios.KeepAliveConns), suite.ConfGaurunDefault.Core.WorkerNum)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.Topic, "")
 	// Log
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Log.AccessLog, "stdout")
@@ -62,9 +62,9 @@ func (suite *ConfigTestSuite) TestValidateConfDefault() {
 func (suite *ConfigTestSuite) TestValidateConf() {
 	// Core
 	assert.Equal(suite.T(), suite.ConfGaurun.Core.Port, "1056")
-	assert.Equal(suite.T(), suite.ConfGaurun.Core.WorkerNum, 8)
-	assert.Equal(suite.T(), suite.ConfGaurun.Core.QueueNum, 8192)
-	assert.Equal(suite.T(), suite.ConfGaurun.Core.NotificationMax, 100)
+	assert.Equal(suite.T(), suite.ConfGaurun.Core.WorkerNum, int64(8))
+	assert.Equal(suite.T(), suite.ConfGaurun.Core.QueueNum, int64(8192))
+	assert.Equal(suite.T(), suite.ConfGaurun.Core.NotificationMax, int64(100))
 	assert.Equal(suite.T(), suite.ConfGaurun.Core.PusherMax, int64(0))
 	// Android
 	assert.Equal(suite.T(), suite.ConfGaurun.Android.Enabled, true)

--- a/gaurun/notification.go
+++ b/gaurun/notification.go
@@ -274,7 +274,7 @@ func PushNotificationHandler(w http.ResponseWriter, r *http.Request) {
 		LogError.Error("empty notification")
 		sendResponse(w, "empty notification", http.StatusBadRequest)
 		return
-	} else if len(reqGaurun.Notifications) > ConfGaurun.Core.NotificationMax {
+	} else if int64(len(reqGaurun.Notifications)) > ConfGaurun.Core.NotificationMax {
 		msg := fmt.Sprintf("number of notifications(%d) over limit(%d)", len(reqGaurun.Notifications), ConfGaurun.Core.NotificationMax)
 		LogError.Error(msg)
 		sendResponse(w, msg, http.StatusBadRequest)

--- a/gaurun/worker.go
+++ b/gaurun/worker.go
@@ -15,9 +15,9 @@ func init() {
 	PusherCount = 0
 }
 
-func StartPushWorkers(workerNum, queueNum int) {
+func StartPushWorkers(workerNum, queueNum int64) {
 	QueueNotification = make(chan RequestGaurunNotification, queueNum)
-	for i := 0; i < workerNum; i++ {
+	for i := int64(0); i < workerNum; i++ {
 		go pushNotificationWorker()
 	}
 }


### PR DESCRIPTION
These parameters will be dynamic values by API. Therefore what atomic.(Store|Load)IntXX is available is required.
