### PR TITLE
use zap instead of logrus

### DIFF
--- a/cmd/gaurun/gaurun.go
+++ b/cmd/gaurun/gaurun.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"io/ioutil"
-	"log"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/mercari/gaurun/gaurun"
@@ -35,7 +34,7 @@ func main() {
 	// load configuration
 	conf, err := gaurun.LoadConf(gaurun.ConfGaurun, *confPath)
 	if err != nil {
-		gaurun.LogError.Fatal(err)
+		gaurun.LogSetupError(err)
 	}
 	gaurun.ConfGaurun = conf
 
@@ -57,46 +56,46 @@ func main() {
 	// set logger
 	err = gaurun.SetLogLevel(gaurun.LogAccess, "info")
 	if err != nil {
-		log.Fatal(err)
+		gaurun.LogSetupError(err)
 	}
 	err = gaurun.SetLogLevel(gaurun.LogError, gaurun.ConfGaurun.Log.Level)
 	if err != nil {
-		log.Fatal(err)
+		gaurun.LogSetupError(err)
 	}
 	err = gaurun.SetLogOut(gaurun.LogAccess, gaurun.ConfGaurun.Log.AccessLog)
 	if err != nil {
-		log.Fatal(err)
+		gaurun.LogSetupError(err)
 	}
 	err = gaurun.SetLogOut(gaurun.LogError, gaurun.ConfGaurun.Log.ErrorLog)
 	if err != nil {
-		log.Fatal(err)
+		gaurun.LogSetupError(err)
 	}
 
 	if !gaurun.ConfGaurun.Ios.Enabled && !gaurun.ConfGaurun.Android.Enabled {
-		gaurun.LogError.Fatal("What do you want to do?")
+		gaurun.LogSetupError(fmt.Errorf("What do you want to do?"))
 	}
 
 	if gaurun.ConfGaurun.Ios.Enabled {
 		gaurun.CertificatePemIos.Cert, err = ioutil.ReadFile(gaurun.ConfGaurun.Ios.PemCertPath)
 		if err != nil {
-			gaurun.LogError.Fatal("A certification file for iOS is not found.")
+			gaurun.LogSetupError(fmt.Errorf("A certification file for iOS is not found."))
 		}
 
 		gaurun.CertificatePemIos.Key, err = ioutil.ReadFile(gaurun.ConfGaurun.Ios.PemKeyPath)
 		if err != nil {
-			gaurun.LogError.Fatal("A key file for iOS is not found.")
+			gaurun.LogSetupError(fmt.Errorf("A key file for iOS is not found."))
 		}
 
 	}
 
 	if gaurun.ConfGaurun.Android.Enabled {
 		if gaurun.ConfGaurun.Android.ApiKey == "" {
-			gaurun.LogError.Fatal("APIKey for Android is empty.")
+			gaurun.LogSetupError(fmt.Errorf("APIKey for Android is empty."))
 		}
 	}
 
 	if err := gaurun.InitHttpClient(); err != nil {
-		gaurun.LogError.Fatal("failed to init http client")
+		gaurun.LogSetupError(fmt.Errorf("failed to init http client"))
 	}
 	gaurun.InitStat()
 	gaurun.StartPushWorkers(gaurun.ConfGaurun.Core.WorkerNum, gaurun.ConfGaurun.Core.QueueNum)

--- a/cmd/gaurun/gaurun.go
+++ b/cmd/gaurun/gaurun.go
@@ -27,7 +27,7 @@ func main() {
 	// load configuration
 	conf, err := gaurun.LoadConf(gaurun.ConfGaurun, *confPath)
 	if err != nil {
-		gaurun.LogSetupError(err)
+		gaurun.LogSetupFatal(err)
 	}
 	gaurun.ConfGaurun = conf
 
@@ -49,48 +49,48 @@ func main() {
 	// set logger
 	accessLogger, err := gaurun.InitLog(gaurun.ConfGaurun.Log.AccessLog)
 	if err != nil {
-		gaurun.LogSetupError(err)
+		gaurun.LogSetupFatal(err)
 	}
 	errorLogger, err := gaurun.InitLog(gaurun.ConfGaurun.Log.ErrorLog)
 	if err != nil {
-		gaurun.LogSetupError(err)
+		gaurun.LogSetupFatal(err)
 	}
 
 	if err := gaurun.SetLogLevel(accessLogger, "info"); err != nil {
-		gaurun.LogSetupError(err)
+		gaurun.LogSetupFatal(err)
 	}
 	if err := gaurun.SetLogLevel(errorLogger, gaurun.ConfGaurun.Log.Level); err != nil {
-		gaurun.LogSetupError(err)
+		gaurun.LogSetupFatal(err)
 	}
 
 	gaurun.LogAccess = accessLogger
 	gaurun.LogError = errorLogger
 
 	if !gaurun.ConfGaurun.Ios.Enabled && !gaurun.ConfGaurun.Android.Enabled {
-		gaurun.LogSetupError(fmt.Errorf("What do you want to do?"))
+		gaurun.LogSetupFatal(fmt.Errorf("What do you want to do?"))
 	}
 
 	if gaurun.ConfGaurun.Ios.Enabled {
 		gaurun.CertificatePemIos.Cert, err = ioutil.ReadFile(gaurun.ConfGaurun.Ios.PemCertPath)
 		if err != nil {
-			gaurun.LogSetupError(fmt.Errorf("A certification file for iOS is not found."))
+			gaurun.LogSetupFatal(fmt.Errorf("A certification file for iOS is not found."))
 		}
 
 		gaurun.CertificatePemIos.Key, err = ioutil.ReadFile(gaurun.ConfGaurun.Ios.PemKeyPath)
 		if err != nil {
-			gaurun.LogSetupError(fmt.Errorf("A key file for iOS is not found."))
+			gaurun.LogSetupFatal(fmt.Errorf("A key file for iOS is not found."))
 		}
 
 	}
 
 	if gaurun.ConfGaurun.Android.Enabled {
 		if gaurun.ConfGaurun.Android.ApiKey == "" {
-			gaurun.LogSetupError(fmt.Errorf("APIKey for Android is empty."))
+			gaurun.LogSetupFatal(fmt.Errorf("APIKey for Android is empty."))
 		}
 	}
 
 	if err := gaurun.InitHttpClient(); err != nil {
-		gaurun.LogSetupError(fmt.Errorf("failed to init http client"))
+		gaurun.LogSetupFatal(fmt.Errorf("failed to init http client"))
 	}
 	gaurun.InitStat()
 	gaurun.StartPushWorkers(gaurun.ConfGaurun.Core.WorkerNum, gaurun.ConfGaurun.Core.QueueNum)

--- a/cmd/gaurun_recover/gaurun_recover.go
+++ b/cmd/gaurun_recover/gaurun_recover.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"strings"
 	"sync"
 	"time"
 
@@ -112,11 +111,9 @@ func main() {
 	for scanner.Scan() {
 		var logPush gaurun.LogPushEntry
 		line := scanner.Text()
-		idx := strings.Index(line, " ")
-		JSONStr := line[idx+1:]
-		err := json.Unmarshal([]byte(JSONStr), &logPush)
+		err := json.Unmarshal([]byte(line), &logPush)
 		if err != nil {
-			log.Printf("JSON parse error(%s)", JSONStr)
+			log.Printf("JSON parse error(%s)", line)
 			continue
 		}
 		if logPush.Type == "accepted-request" {

--- a/cmd/gaurun_recover/gaurun_recover.go
+++ b/cmd/gaurun_recover/gaurun_recover.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"os"

--- a/cmd/gaurun_recover/gaurun_recover.go
+++ b/cmd/gaurun_recover/gaurun_recover.go
@@ -94,7 +94,7 @@ func main() {
 	// load configuration
 	conf, err := gaurun.LoadConf(gaurun.ConfGaurun, *confPath)
 	if err != nil {
-		gaurun.LogSetupError(err)
+		gaurun.LogSetupFatal(err)
 	}
 	gaurun.ConfGaurun = conf
 
@@ -140,7 +140,7 @@ func main() {
 		gaurun.ConfGaurun.Ios.PemKeyPath,
 	)
 	if err != nil {
-		gaurun.LogSetupError(err)
+		gaurun.LogSetupFatal(err)
 	}
 	APNSClient.Timeout = time.Duration(gaurun.ConfGaurun.Ios.Timeout) * time.Second
 

--- a/cmd/gaurun_recover/gaurun_recover.go
+++ b/cmd/gaurun_recover/gaurun_recover.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"os"
@@ -95,7 +94,7 @@ func main() {
 	// load configuration
 	conf, err := gaurun.LoadConf(gaurun.ConfGaurun, *confPath)
 	if err != nil {
-		log.Fatal(err)
+		gaurun.LogSetupError(err)
 	}
 	gaurun.ConfGaurun = conf
 
@@ -143,7 +142,7 @@ func main() {
 		gaurun.ConfGaurun.Ios.PemKeyPath,
 	)
 	if err != nil {
-		log.Fatal(err)
+		gaurun.LogSetupError(err)
 	}
 	APNSClient.Timeout = time.Duration(gaurun.ConfGaurun.Ios.Timeout) * time.Second
 

--- a/gaurun/conf.go
+++ b/gaurun/conf.go
@@ -123,7 +123,7 @@ func ConfigPushersHandler(w http.ResponseWriter, r *http.Request) {
 
 	values, err := url.ParseQuery(r.URL.RawQuery)
 	if err != nil {
-		LogError.Error(err)
+		LogError.Error(err.Error())
 		sendResponse(w, "url parameters could not be parsed", http.StatusBadRequest)
 		return
 	}
@@ -143,7 +143,7 @@ func ConfigPushersHandler(w http.ResponseWriter, r *http.Request) {
 
 	newPusherMax, err := strconv.ParseInt(in, 0, 64)
 	if err != nil {
-		LogError.Error(err)
+		LogError.Error(err.Error())
 		sendResponse(w, "malformed value", http.StatusBadRequest)
 		return
 	}

--- a/gaurun/global.go
+++ b/gaurun/global.go
@@ -4,16 +4,16 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/mercari/gcm"
+	"github.com/uber-go/zap"
 )
 
 var (
 	ConfGaurun        ConfToml
 	QueueNotification chan RequestGaurunNotification
 	CertificatePemIos CertificatePem
-	LogAccess         *logrus.Logger
-	LogError          *logrus.Logger
+	LogAccess         zap.Logger
+	LogError          zap.Logger
 	StatGaurun        StatApp
 	// for numbering push
 	OnceNumbering sync.Once

--- a/gaurun/log.go
+++ b/gaurun/log.go
@@ -68,8 +68,8 @@ func SetLogLevel(log zap.Logger, levelString string) error {
 	return nil
 }
 
-// LogSetupError output error log with log package and exit immediately.
-func LogSetupError(err error) {
+// LogSetupFatal output error log with log package and exit immediately.
+func LogSetupFatal(err error) {
 	log.Fatal(err)
 }
 

--- a/gaurun/log.go
+++ b/gaurun/log.go
@@ -74,7 +74,8 @@ func LogSetupError(err error) {
 }
 
 func LogAcceptedRequest(uri, method, proto string, length int64) {
-	LogAccess.Info("accepted-request",
+	LogAccess.Info("",
+		zap.String("type", "accepted-request"),
 		zap.String("uri", uri),
 		zap.String("method", method),
 		zap.String("proto", proto),

--- a/gaurun/log.go
+++ b/gaurun/log.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 	"sync/atomic"
@@ -79,6 +80,11 @@ func SetLogLevel(log *logrus.Logger, levelString string) error {
 	}
 	log.Level = level
 	return nil
+}
+
+// LogSetupError output error log with log package and exit immediately.
+func LogSetupError(err error) {
+	log.Fatal(err)
 }
 
 func LogAcceptedRequest(uri, method, proto string, length int64) {

--- a/gaurun/log.go
+++ b/gaurun/log.go
@@ -55,6 +55,7 @@ func InitLog(outString string) (zap.Logger, error) {
 	}
 
 	encoder := zap.NewJSONEncoder(
+		zap.MessageKey("message"),
 		zap.TimeFormatter(func(t time.Time) zap.Field {
 			return zap.String("time", t.Local().Format("2006/01/02 15:04:05 MST"))
 		}),

--- a/gaurun/log.go
+++ b/gaurun/log.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"os"
 	"sync/atomic"
+	"time"
 
 	"github.com/uber-go/zap"
 )
@@ -54,7 +55,9 @@ func InitLog(outString string) (zap.Logger, error) {
 	}
 
 	encoder := zap.NewJSONEncoder(
-		zap.RFC3339Formatter("time"),
+		zap.TimeFormatter(func(t time.Time) zap.Field {
+			return zap.String("time", t.Local().Format("2006/01/02 15:04:05 MST"))
+		}),
 	)
 	return zap.New(encoder, zap.Output(writer), zap.ErrorOutput(writer)), nil
 }

--- a/gaurun/log.go
+++ b/gaurun/log.go
@@ -1,10 +1,9 @@
 package gaurun
 
 import (
-	"fmt"
 	"log"
+	"math"
 	"os"
-	"strconv"
 	"sync/atomic"
 
 	"github.com/uber-go/zap"
@@ -92,8 +91,7 @@ func LogPush(id uint64, status, token string, ptime float64, req RequestGaurunNo
 		plat = "android"
 	}
 
-	ptime3 := fmt.Sprintf("%.3f", ptime)
-	ptime, _ = strconv.ParseFloat(ptime3, 64)
+	ptime = math.Floor(ptime*1000) / 1000 // %.3f conversion
 
 	errMsg := ""
 	if errPush != nil {

--- a/gaurun/log.go
+++ b/gaurun/log.go
@@ -1,16 +1,13 @@
 package gaurun
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
 	"strconv"
 	"sync/atomic"
-	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/uber-go/zap"
 )
 
 type LogReq struct {
@@ -42,43 +39,33 @@ type LogPushEntry struct {
 	Expiry           int    `json:"expiry,omitempty"`
 }
 
-type GaurunFormatter struct {
-}
-
-func (f *GaurunFormatter) Format(entry *logrus.Entry) ([]byte, error) {
-	b := &bytes.Buffer{}
-	fmt.Fprintf(b, "[%s] ", entry.Level.String())
-	fmt.Fprintf(b, "%s", entry.Message)
-	b.WriteByte('\n')
-	return b.Bytes(), nil
-}
-
-func InitLog() *logrus.Logger {
-	return logrus.New()
-}
-
-func SetLogOut(log *logrus.Logger, outString string) error {
+func InitLog(outString string) (zap.Logger, error) {
+	var writer zap.WriteSyncer
 	switch outString {
 	case "stdout":
-		log.Out = os.Stdout
+		writer = os.Stdout
 	case "stderr":
-		log.Out = os.Stderr
+		writer = os.Stderr
 	default:
 		f, err := os.OpenFile(outString, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		log.Out = f
+		writer = f
 	}
-	return nil
+
+	encoder := zap.NewJSONEncoder(
+		zap.RFC3339Formatter("time"),
+	)
+	return zap.New(encoder, zap.Output(writer), zap.ErrorOutput(writer)), nil
 }
 
-func SetLogLevel(log *logrus.Logger, levelString string) error {
-	level, err := logrus.ParseLevel(levelString)
-	if err != nil {
+func SetLogLevel(log zap.Logger, levelString string) error {
+	var level zap.Level
+	if err := level.UnmarshalText([]byte(levelString)); err != nil {
 		return err
 	}
-	log.Level = level
+	log.SetLevel(level)
 	return nil
 }
 
@@ -88,20 +75,12 @@ func LogSetupError(err error) {
 }
 
 func LogAcceptedRequest(uri, method, proto string, length int64) {
-	log := &LogReq{
-		Type:          "accepted-request",
-		Time:          time.Now().Format("2006/01/02 15:04:05 MST"),
-		URI:           uri,
-		Method:        method,
-		Proto:         proto,
-		ContentLength: length,
-	}
-	logJSON, err := json.Marshal(log)
-	if err != nil {
-		LogError.Error("Marshaling JSON error")
-		return
-	}
-	LogAccess.Info(string(logJSON))
+	LogAccess.Info("accepted-request",
+		zap.String("uri", uri),
+		zap.String("method", method),
+		zap.String("proto", proto),
+		zap.Int64("content_length", length),
+	)
 }
 
 func LogPush(id uint64, status, token string, ptime float64, req RequestGaurunNotification, errPush error) {
@@ -121,37 +100,61 @@ func LogPush(id uint64, status, token string, ptime float64, req RequestGaurunNo
 		errMsg = errPush.Error()
 	}
 
-	log := &LogPushEntry{
-		Type:             status,
-		Time:             time.Now().Format("2006/01/02 15:04:05 MST"),
-		ID:               id,
-		Platform:         plat,
-		Token:            token,
-		Message:          req.Message,
-		Ptime:            ptime,
-		Error:            errMsg,
-		CollapseKey:      req.CollapseKey,
-		DelayWhileIdle:   req.DelayWhileIdle,
-		TimeToLive:       req.TimeToLive,
-		Badge:            req.Badge,
-		Sound:            req.Sound,
-		ContentAvailable: req.ContentAvailable,
-		Expiry:           req.Expiry,
-	}
-	logJSON, err := json.Marshal(log)
-	if err != nil {
-		LogError.Error("Marshaling JSON error")
-		return
-	}
-
+	var logger func(string, ...zap.Field)
 	switch status {
 	case StatusAcceptedPush:
 		fallthrough
 	case StatusSucceededPush:
-		LogAccess.Info(string(logJSON))
+		logger = LogAccess.Info
 	case StatusFailedPush:
-		LogError.Error(string(logJSON))
+		logger = LogError.Error
 	}
+
+	// omitempty handling for device dependent values
+	collapseKey := zap.Skip()
+	if req.CollapseKey != "" {
+		collapseKey = zap.String("collapse_key", req.CollapseKey)
+	}
+	delayWhileIdle := zap.Skip()
+	if req.DelayWhileIdle {
+		delayWhileIdle = zap.Bool("delay_while_idle", req.DelayWhileIdle)
+	}
+	timeToLive := zap.Skip()
+	if req.TimeToLive != 0 {
+		timeToLive = zap.Int("time_to_live", req.TimeToLive)
+	}
+	badge := zap.Skip()
+	if req.Badge != 0 {
+		badge = zap.Int("badge", req.Badge)
+	}
+	sound := zap.Skip()
+	if req.Sound != "" {
+		sound = zap.String("sound", req.Sound)
+	}
+	contentAvailable := zap.Skip()
+	if req.ContentAvailable {
+		contentAvailable = zap.Bool("content_available", req.ContentAvailable)
+	}
+	expiry := zap.Skip()
+	if req.Expiry != 0 {
+		expiry = zap.Int("expiry", req.Expiry)
+	}
+
+	logger(req.Message,
+		zap.Uint64("id", id),
+		zap.String("platform", plat),
+		zap.String("token", token),
+		zap.String("type", status),
+		zap.Float64("ptime", ptime),
+		zap.String("error", errMsg),
+		collapseKey,
+		delayWhileIdle,
+		timeToLive,
+		badge,
+		sound,
+		contentAvailable,
+		expiry,
+	)
 }
 
 func numberingPush() uint64 {

--- a/gaurun/log_test.go
+++ b/gaurun/log_test.go
@@ -1,0 +1,37 @@
+package gaurun
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/uber-go/zap"
+)
+
+func init() {
+	LogAccess = zap.New(zap.NewJSONEncoder(zap.RFC3339Formatter("time")), zap.DiscardOutput)
+	LogError = zap.New(zap.NewJSONEncoder(zap.RFC3339Formatter("time")), zap.DiscardOutput)
+}
+
+func BenchmarkLogPushIOSOmitempty(b *testing.B) {
+	req := RequestGaurunNotification{
+		Platform: PlatFormIos,
+	}
+	errPush := fmt.Errorf("error")
+	for i := 0; i < b.N; i++ {
+		LogPush(uint64(100), StatusAcceptedPush, "xxx", 0.123, req, errPush)
+	}
+}
+
+func BenchmarkLogPushIOSFull(b *testing.B) {
+	req := RequestGaurunNotification{
+		Platform:         PlatFormIos,
+		Badge:            1,
+		Sound:            "foo",
+		ContentAvailable: true,
+		Expiry:           100,
+	}
+	errPush := fmt.Errorf("error")
+	for i := 0; i < b.N; i++ {
+		LogPush(uint64(100), StatusAcceptedPush, "xxx", 0.123, req, errPush)
+	}
+}

--- a/gaurun/log_test.go
+++ b/gaurun/log_test.go
@@ -3,13 +3,20 @@ package gaurun
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/uber-go/zap"
 )
 
 func init() {
-	LogAccess = zap.New(zap.NewJSONEncoder(zap.RFC3339Formatter("time")), zap.DiscardOutput)
-	LogError = zap.New(zap.NewJSONEncoder(zap.RFC3339Formatter("time")), zap.DiscardOutput)
+	encoder := zap.NewJSONEncoder(
+		zap.MessageKey("message"),
+		zap.TimeFormatter(func(t time.Time) zap.Field {
+			return zap.String("time", t.Local().Format("2006/01/02 15:04:05 MST"))
+		}),
+	)
+	LogAccess = zap.New(encoder, zap.DiscardOutput)
+	LogError = zap.New(encoder, zap.DiscardOutput)
 }
 
 func BenchmarkLogPushIOSOmitempty(b *testing.B) {

--- a/gaurun/worker.go
+++ b/gaurun/worker.go
@@ -1,6 +1,7 @@
 package gaurun
 
 import (
+	"fmt"
 	"strings"
 	"sync/atomic"
 
@@ -75,7 +76,7 @@ func pushNotificationWorker() {
 			pusher = pushNotificationAndroid
 			retryMax = ConfGaurun.Android.RetryMax
 		default:
-			LogError.Warnf("invalid platform: %d", notification.Platform)
+			LogError.Warn(fmt.Sprintf("invalid platform: %d", notification.Platform))
 			continue
 		}
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: a6443b44da0790750567bba0e3bba4887c8c4c7f1f90e7c014f970bffabbd2fb
-updated: 2016-08-28T19:44:15.038360984+09:00
+hash: 149b93bd592f0c639ddd4777f3f496feff57278c5e5d6722e8bcd5207cb7fbfe
+updated: 2016-09-28T17:45:43.557952286+09:00
 imports:
 - name: github.com/BurntSushi/toml
   version: bbd5bb678321a0d6e58f1099321dfa73391c1b6f
@@ -17,17 +17,19 @@ imports:
   version: f390dcf405f7b83c997eac1b06768bb9f44dec18
   subpackages:
   - assert
-  - suite
   - require
+  - suite
 - name: github.com/uber-go/atomic
   version: 0c9e689d64f004564b79d9a663634756df322902
 - name: github.com/uber-go/zap
-  version: d11d2851fcabcf03421c4dbdbc3146fc74eb1035
+  version: f1942381637c11a802c356e70ab5b0a953540bb5
 - name: golang.org/x/net
-  version: b797637b7aeeed133049c7281bfa31dcc9ca42d6
+  version: f09c4662a0bd6bd8943ac7b4931e185df9471da4
   subpackages:
   - http2
   - http2/hpack
+  - idna
+  - lex/httplex
 testImports:
 - name: github.com/davecgh/go-spew
   version: 2df174808ee097f90d259e432cc04442cf60be21

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 8bf57a9cc5db0bc0cca2797499a6a3754733e3841d9ec2bcf72f74f6ce6364fa
-updated: 2016-06-13T11:53:25.375685652+09:00
+hash: a6443b44da0790750567bba0e3bba4887c8c4c7f1f90e7c014f970bffabbd2fb
+updated: 2016-08-28T19:44:15.038360984+09:00
 imports:
 - name: github.com/BurntSushi/toml
   version: bbd5bb678321a0d6e58f1099321dfa73391c1b6f
@@ -13,17 +13,27 @@ imports:
   - payload
   - payload/badge
   - push
-- name: github.com/Sirupsen/logrus
-  version: 4b6ea7319e214d98c938f12692336f7ca9348d6b
 - name: github.com/stretchr/testify
   version: f390dcf405f7b83c997eac1b06768bb9f44dec18
+  subpackages:
+  - assert
+  - suite
+  - require
+- name: github.com/uber-go/atomic
+  version: 0c9e689d64f004564b79d9a663634756df322902
+- name: github.com/uber-go/zap
+  version: d11d2851fcabcf03421c4dbdbc3146fc74eb1035
 - name: golang.org/x/net
   version: b797637b7aeeed133049c7281bfa31dcc9ca42d6
   subpackages:
   - http2
   - http2/hpack
-- name: golang.org/x/sys
-  version: f64b50fbea64174967a8882830d621a18ee1548e
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 2df174808ee097f90d259e432cc04442cf60be21
   subpackages:
-  - unix
-devImports: []
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib

--- a/glide.yaml
+++ b/glide.yaml
@@ -15,3 +15,4 @@ import:
 - package: github.com/stretchr/testify
   version: v1.1.3
 - package: github.com/uber-go/zap
+  version: f1942381637c11a802c356e70ab5b0a953540bb5

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,11 +8,10 @@ import:
   - payload
   - payload/badge
   - push
-- package: github.com/Sirupsen/logrus
-  version: v0.10.0
 - package: github.com/mercari/gcm
   version: 987b1dc4ce9034b698395d35de1aadf999388b8f
 - package: github.com/fukata/golang-stats-api-handler
   version: e7ee1630fdb679c86ec8e3d0755e3576675fdb10
 - package: github.com/stretchr/testify
   version: v1.1.3
+- package: github.com/uber-go/zap


### PR DESCRIPTION
use github.com/uber-go/zap instead of github.com/Sirupsen/logrus for access/error logs. This breaks compatibility about log format and achieves fully json logging.

zap is very complex to use (ex: omitempty), but slightly faster than other loggers. This is a benchmark before/after this changes for `gaurun.LogPush`.

**before**

```
go test github.com/mercari/gaurun/gaurun -benchmem -benchtime 5s -bench .   
BenchmarkLogPushIOSOmitempty-4   	  500000	     12257 ns/op	    1816 B/op	      18 allocs/op
BenchmarkLogPushIOSFull-4        	  500000	     13893 ns/op	    2008 B/op	      18 allocs/op
```

**after**

```
go test github.com/mercari/gaurun/gaurun -benchmem -benchtime 5s -bench .     
BenchmarkLogPushIOSOmitempty-4   	 1000000	      6060 ns/op	     945 B/op	       4 allocs/op
BenchmarkLogPushIOSFull-4        	 1000000	      6303 ns/op	     945 B/op	       4 allocs/op
```

2 allocs for zap logging. 2 allocs for `ptime`'s format conversion.

**EDIT:**

After removing format conversion and computing the value instead.

```
go test github.com/mercari/gaurun/gaurun -benchmem -benchtime 5s -bench . 
BenchmarkLogPushIOSOmitempty-4   	 2000000	      4574 ns/op	     929 B/op	       2 allocs/op
BenchmarkLogPushIOSFull-4        	 1000000	      5030 ns/op	     929 B/op	       2 allocs/op
```

*change list*

- log format change
 - `[info] {"message": "...", ...}` to `{"level":"info","message":"..."...}`
- time format
 - `2015/08/04 15:32:35 JST` (local time) to `2016-08-30T01:18:04Z` (UTC)
- 