### PR TITLE
optimize: mitigated the blocking between each worker.

### DIFF
--- a/gaurun/stat.go
+++ b/gaurun/stat.go
@@ -39,8 +39,8 @@ func StatsHandler(w http.ResponseWriter, r *http.Request) {
 	var result StatApp
 	result.QueueMax = cap(QueueNotification)
 	result.QueueUsage = len(QueueNotification)
-	result.PusherMax = ConfGaurun.Core.PusherMax
-	result.PusherCount = atomic.LoadInt64(&PusherCount)
+	result.PusherMax = ConfGaurun.Core.PusherMax * ConfGaurun.Core.WorkerNum
+	result.PusherCount = atomic.LoadInt64(&PusherCountAll)
 	result.Ios.PushSuccess = atomic.LoadInt64(&StatGaurun.Ios.PushSuccess)
 	result.Ios.PushError = atomic.LoadInt64(&StatGaurun.Ios.PushError)
 	result.Android.PushSuccess = atomic.LoadInt64(&StatGaurun.Android.PushSuccess)

--- a/gaurun/worker.go
+++ b/gaurun/worker.go
@@ -8,11 +8,12 @@ import (
 )
 
 var (
-	PusherCount int64
+	// pusherCountAll is the shared value between each worker
+	PusherCountAll int64
 )
 
 func init() {
-	PusherCount = 0
+	PusherCountAll = 0
 }
 
 func StartPushWorkers(workerNum, queueNum int64) {
@@ -47,7 +48,7 @@ Retry:
 	}
 }
 
-func pushAsync(pusher func(req RequestGaurunNotification) error, req RequestGaurunNotification, retryMax int) {
+func pushAsync(pusher func(req RequestGaurunNotification) error, req RequestGaurunNotification, retryMax int, pusherCount *int64) {
 Retry:
 	err := pusher(req)
 	if err != nil && req.Retry < retryMax && isExternalServerError(err, req.Platform) {
@@ -55,14 +56,19 @@ Retry:
 		goto Retry
 	}
 
-	atomic.AddInt64(&PusherCount, -1)
+	*pusherCount = *pusherCount - 1
+	atomic.AddInt64(&PusherCountAll, -1)
 }
 
 func pushNotificationWorker() {
 	var (
-		retryMax int
-		pusher   func(req RequestGaurunNotification) error
+		retryMax    int
+		pusher      func(req RequestGaurunNotification) error
+		pusherCount int64
 	)
+
+	// pusherCount is the independent value between each worker
+	pusherCount = 0
 
 	for {
 		notification := <-QueueNotification
@@ -84,13 +90,14 @@ func pushNotificationWorker() {
 			continue
 		}
 
-		if atomic.LoadInt64(&PusherCount) < atomic.LoadInt64(&ConfGaurun.Core.PusherMax) {
-			// Do not increment PusherCount in pushAsync().
-			// Because PusherCount is sometimes over pusherMax
+		if pusherCount < atomic.LoadInt64(&ConfGaurun.Core.PusherMax) {
+			// Do not increment pusherCount and PusherCountAll in pushAsync().
+			// Because pusherCount and PusherCountAll are sometimes over pusherMax
 			// as the increment in goroutine runs asynchronously.
-			atomic.AddInt64(&PusherCount, 1)
+			pusherCount++
+			atomic.AddInt64(&PusherCountAll, 1)
 
-			go pushAsync(pusher, notification, retryMax)
+			go pushAsync(pusher, notification, retryMax, &pusherCount)
 			continue
 		} else {
 			pushSync(pusher, notification, retryMax)


### PR DESCRIPTION
Previously pusherCount and pusher_max were the shared value between each worker. Each worker tends to be blocked because pusherCount is reached quickly.

This implementation makes pusherCount independent between each worker and gives pusher_max to each worker.