### PR TITLE
optimize: mitigated the blocking between workers.

### DIFF
--- a/gaurun/stat.go
+++ b/gaurun/stat.go
@@ -39,8 +39,8 @@ func StatsHandler(w http.ResponseWriter, r *http.Request) {
 	var result StatApp
 	result.QueueMax = cap(QueueNotification)
 	result.QueueUsage = len(QueueNotification)
-	result.PusherMax = ConfGaurun.Core.PusherMax
-	result.PusherCount = atomic.LoadInt64(&PusherCount)
+	result.PusherMax = ConfGaurun.Core.PusherMax * ConfGaurun.Core.WorkerNum
+	result.PusherCount = atomic.LoadInt64(&PusherCountAll)
 	result.Ios.PushSuccess = atomic.LoadInt64(&StatGaurun.Ios.PushSuccess)
 	result.Ios.PushError = atomic.LoadInt64(&StatGaurun.Ios.PushError)
 	result.Android.PushSuccess = atomic.LoadInt64(&StatGaurun.Android.PushSuccess)

--- a/gaurun/worker.go
+++ b/gaurun/worker.go
@@ -56,7 +56,7 @@ Retry:
 		goto Retry
 	}
 
-	*pusherCount = *pusherCount - 1
+	atomic.AddInt64(pusherCount, -1)
 	atomic.AddInt64(&PusherCountAll, -1)
 }
 
@@ -90,11 +90,11 @@ func pushNotificationWorker() {
 			continue
 		}
 
-		if pusherCount < atomic.LoadInt64(&ConfGaurun.Core.PusherMax) {
+		if atomic.LoadInt64(&pusherCount) < atomic.LoadInt64(&ConfGaurun.Core.PusherMax) {
 			// Do not increment pusherCount and PusherCountAll in pushAsync().
 			// Because pusherCount and PusherCountAll are sometimes over pusherMax
 			// as the increment in goroutine runs asynchronously.
-			pusherCount++
+			atomic.AddInt64(&pusherCount, 1)
 			atomic.AddInt64(&PusherCountAll, 1)
 
 			go pushAsync(pusher, notification, retryMax, &pusherCount)

--- a/gaurun/worker.go
+++ b/gaurun/worker.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	// pusherCountAll is the shared value between workers
+	// PusherCountAll is the shared value between workers
 	PusherCountAll int64
 )
 


### PR DESCRIPTION
Previously `pusherCount` and `pusher_max` were the shared value between workers. Workers tend to be blocked because `pusherCount` reaches `pusher_max` quickly.

This implementation makes `pusherCount` independent by each worker and gives `pusher_max` to each worker.