### PR TITLE
APNs, GCM: introduced http.Transport.IdleConnTimeout from Go1.7.

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -29,7 +29,7 @@ The configuration for Gaurun has some sections. The example is [here](conf/gauru
 |sandbox               |bool  |On/Off for sandbox environment                        |true      |                               |
 |retry_max             |int   |maximum retry count for push notication to APNs       |1         |                               |
 |timeout               |int   |timeout for push notification to APNs                 |5         |                               |
-|keepalive_timeout     |int   |time for continuing keep-alive connection to APNs     |30        |                               |
+|keepalive_timeout     |int   |time for continuing keep-alive connection to APNs     |90        |                               |
 |keepalive_conns       |int   |number of keep-alive connection to APNs               |runtime.NumCPU()|                         |
 |topic                 |string|the assigned value of `apns-topic` for Request headers|          |                               |
 
@@ -42,7 +42,7 @@ The configuration for Gaurun has some sections. The example is [here](conf/gauru
 |enabled          |bool  |On/Off for push notication to GCM               |true   |    |
 |apikey           |string|API key string for GCM                          |       |    |
 |timeout          |int   |timeout for push notication to GCM              |5(sec) |    |
-|keepalive_timeout|int   |time for continuing keep-alive connection to GCM|30     |    |
+|keepalive_timeout|int   |time for continuing keep-alive connection to GCM|90     |    |
 |keepalive_conns  |int   |number of keep-alive connection to GCM          |runtime.NumCPU()||
 |retry_max        |int   |maximum retry count for push notication to GCM  |1      |    |
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Gaurun is production ready.
 
 ## Requirements
 
-Gaurun requires Go1.6.3 or later.
+Gaurun requires Go1.7.3 or later.
 
 ## Supported Platforms
 

--- a/gaurun/apns_http2.go
+++ b/gaurun/apns_http2.go
@@ -25,7 +25,7 @@ func NewTransportHttp2(cert tls.Certificate) (*http.Transport, error) {
 		MaxIdleConnsPerHost: ConfGaurun.Ios.KeepAliveConns,
 		Dial: (&net.Dialer{
 			Timeout:   time.Duration(ConfGaurun.Ios.Timeout) * time.Second,
-			KeepAlive: keepAliveInterval(ConfGaurun.Ios.KeepAliveTimeout),
+			KeepAlive: time.Duration(keepAliveInterval(ConfGaurun.Ios.KeepAliveTimeout)) * time.Second,
 		}).Dial,
 		IdleConnTimeout: time.Duration(ConfGaurun.Ios.KeepAliveTimeout) * time.Second,
 	}

--- a/gaurun/apns_http2.go
+++ b/gaurun/apns_http2.go
@@ -27,6 +27,7 @@ func NewTransportHttp2(cert tls.Certificate) (*http.Transport, error) {
 			Timeout:   time.Duration(ConfGaurun.Ios.Timeout) * time.Second,
 			KeepAlive: time.Duration(ConfGaurun.Ios.KeepAliveTimeout) * time.Second,
 		}).Dial,
+		IdleConnTimeout: time.Duration(ConfGaurun.Ios.KeepAliveTimeout) * time.Second,
 	}
 
 	if err := http2.ConfigureTransport(transport); err != nil {

--- a/gaurun/apns_http2.go
+++ b/gaurun/apns_http2.go
@@ -25,7 +25,7 @@ func NewTransportHttp2(cert tls.Certificate) (*http.Transport, error) {
 		MaxIdleConnsPerHost: ConfGaurun.Ios.KeepAliveConns,
 		Dial: (&net.Dialer{
 			Timeout:   time.Duration(ConfGaurun.Ios.Timeout) * time.Second,
-			KeepAlive: time.Duration(ConfGaurun.Ios.KeepAliveTimeout) * time.Second,
+			KeepAlive: keepAliveInterval(ConfGaurun.Ios.KeepAliveTimeout),
 		}).Dial,
 		IdleConnTimeout: time.Duration(ConfGaurun.Ios.KeepAliveTimeout) * time.Second,
 	}

--- a/gaurun/client.go
+++ b/gaurun/client.go
@@ -1,0 +1,49 @@
+package gaurun
+
+import (
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/mercari/gcm"
+)
+
+func keepAliveInterval(keepAliveTimeout int) int {
+	const minInterval = 30
+	if keepAliveTimeout <= minInterval {
+		return keepAliveTimeout
+	}
+	result := keepAliveTimeout / 3
+	if result < minInterval {
+		return minInterval
+	}
+	return result
+}
+
+func InitHttpClient() error {
+	TransportGCM := &http.Transport{
+		MaxIdleConnsPerHost: ConfGaurun.Android.KeepAliveConns,
+		Dial: (&net.Dialer{
+			Timeout:   time.Duration(ConfGaurun.Android.Timeout) * time.Second,
+			KeepAlive: keepAliveInterval(ConfGaurun.Android.Timeout),
+		}).Dial,
+		IdleConnTimeout: time.Duration(ConfGaurun.Android.KeepAliveTimeout) * time.Second,
+	}
+	GCMClient = &gcm.Sender{
+		ApiKey: ConfGaurun.Android.ApiKey,
+		Http: &http.Client{
+			Transport: TransportGCM,
+			Timeout:   time.Duration(ConfGaurun.Android.Timeout) * time.Second,
+		},
+	}
+
+	var err error
+	APNSClient, err = NewApnsClientHttp2(
+		ConfGaurun.Ios.PemCertPath,
+		ConfGaurun.Ios.PemKeyPath,
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/gaurun/client.go
+++ b/gaurun/client.go
@@ -25,7 +25,7 @@ func InitHttpClient() error {
 		MaxIdleConnsPerHost: ConfGaurun.Android.KeepAliveConns,
 		Dial: (&net.Dialer{
 			Timeout:   time.Duration(ConfGaurun.Android.Timeout) * time.Second,
-			KeepAlive: keepAliveInterval(ConfGaurun.Android.Timeout),
+			KeepAlive: keepAliveInterval(ConfGaurun.Android.KeepAliveTimeout),
 		}).Dial,
 		IdleConnTimeout: time.Duration(ConfGaurun.Android.KeepAliveTimeout) * time.Second,
 	}

--- a/gaurun/client.go
+++ b/gaurun/client.go
@@ -25,7 +25,7 @@ func InitHttpClient() error {
 		MaxIdleConnsPerHost: ConfGaurun.Android.KeepAliveConns,
 		Dial: (&net.Dialer{
 			Timeout:   time.Duration(ConfGaurun.Android.Timeout) * time.Second,
-			KeepAlive: keepAliveInterval(ConfGaurun.Android.KeepAliveTimeout),
+			KeepAlive: time.Duration(keepAliveInterval(ConfGaurun.Android.KeepAliveTimeout)) * time.Second,
 		}).Dial,
 		IdleConnTimeout: time.Duration(ConfGaurun.Android.KeepAliveTimeout) * time.Second,
 	}

--- a/gaurun/client.go
+++ b/gaurun/client.go
@@ -10,12 +10,16 @@ import (
 
 func keepAliveInterval(keepAliveTimeout int) int {
 	const minInterval = 30
+	const maxInterval = 90
 	if keepAliveTimeout <= minInterval {
 		return keepAliveTimeout
 	}
 	result := keepAliveTimeout / 3
 	if result < minInterval {
 		return minInterval
+	}
+	if result > maxInterval {
+		return maxInterval
 	}
 	return result
 }

--- a/gaurun/client_test.go
+++ b/gaurun/client_test.go
@@ -10,4 +10,6 @@ func TestKeepAliveInterval(t *testing.T) {
 	assert.Equal(t, 30, keepAliveInterval(30))
 	assert.Equal(t, 25, keepAliveInterval(25))
 	assert.Equal(t, 30, keepAliveInterval(50))
+	assert.Equal(t, 90, keepAliveInterval(300))
+	assert.Equal(t, 90, keepAliveInterval(600))
 }

--- a/gaurun/client_test.go
+++ b/gaurun/client_test.go
@@ -1,0 +1,13 @@
+package gaurun
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestKeepAliveInterval(t *testing.T) {
+	assert.Equal(t, 30, keepAliveInterval(90))
+	assert.Equal(t, 30, keepAliveInterval(30))
+	assert.Equal(t, 25, keepAliveInterval(25))
+	assert.Equal(t, 30, keepAliveInterval(50))
+}

--- a/gaurun/conf.go
+++ b/gaurun/conf.go
@@ -68,7 +68,7 @@ func BuildDefaultConf() ConfToml {
 	conf.Android.ApiKey = ""
 	conf.Android.Enabled = true
 	conf.Android.Timeout = 5
-	conf.Android.KeepAliveTimeout = 30
+	conf.Android.KeepAliveTimeout = 90
 	conf.Android.KeepAliveConns = numCPU
 	conf.Android.RetryMax = 1
 	// iOS
@@ -78,7 +78,7 @@ func BuildDefaultConf() ConfToml {
 	conf.Ios.Sandbox = true
 	conf.Ios.RetryMax = 1
 	conf.Ios.Timeout = 5
-	conf.Ios.KeepAliveTimeout = 30
+	conf.Ios.KeepAliveTimeout = 90
 	conf.Ios.KeepAliveConns = numCPU
 	conf.Ios.Topic = ""
 	// log

--- a/gaurun/conf_test.go
+++ b/gaurun/conf_test.go
@@ -40,7 +40,7 @@ func (suite *ConfigTestSuite) TestValidateConfDefault() {
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.Enabled, true)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.ApiKey, "")
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.Timeout, 5)
-	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.KeepAliveTimeout, 30)
+	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.KeepAliveTimeout, 90)
 	assert.Equal(suite.T(), int64(suite.ConfGaurunDefault.Android.KeepAliveConns), suite.ConfGaurunDefault.Core.WorkerNum)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.RetryMax, 1)
 	// Ios
@@ -50,7 +50,7 @@ func (suite *ConfigTestSuite) TestValidateConfDefault() {
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.Sandbox, true)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.RetryMax, 1)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.Timeout, 5)
-	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.KeepAliveTimeout, 30)
+	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.KeepAliveTimeout, 90)
 	assert.Equal(suite.T(), int64(suite.ConfGaurunDefault.Ios.KeepAliveConns), suite.ConfGaurunDefault.Core.WorkerNum)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.Topic, "")
 	// Log

--- a/gaurun/notification.go
+++ b/gaurun/notification.go
@@ -59,6 +59,7 @@ func InitHttpClient() error {
 			Timeout:   time.Duration(ConfGaurun.Android.Timeout) * time.Second,
 			KeepAlive: time.Duration(ConfGaurun.Android.KeepAliveTimeout) * time.Second,
 		}).Dial,
+		IdleConnTimeout: time.Duration(ConfGaurun.Android.KeepAliveTimeout) * time.Second,
 	}
 	GCMClient = &gcm.Sender{
 		ApiKey: ConfGaurun.Android.ApiKey,

--- a/gaurun/notification.go
+++ b/gaurun/notification.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -50,34 +49,6 @@ type ResponseGaurun struct {
 type CertificatePem struct {
 	Cert []byte
 	Key  []byte
-}
-
-func InitHttpClient() error {
-	TransportGCM := &http.Transport{
-		MaxIdleConnsPerHost: ConfGaurun.Android.KeepAliveConns,
-		Dial: (&net.Dialer{
-			Timeout:   time.Duration(ConfGaurun.Android.Timeout) * time.Second,
-			KeepAlive: time.Duration(ConfGaurun.Android.KeepAliveTimeout) * time.Second,
-		}).Dial,
-		IdleConnTimeout: time.Duration(ConfGaurun.Android.KeepAliveTimeout) * time.Second,
-	}
-	GCMClient = &gcm.Sender{
-		ApiKey: ConfGaurun.Android.ApiKey,
-		Http: &http.Client{
-			Transport: TransportGCM,
-			Timeout:   time.Duration(ConfGaurun.Android.Timeout) * time.Second,
-		},
-	}
-
-	var err error
-	APNSClient, err = NewApnsClientHttp2(
-		ConfGaurun.Ios.PemCertPath,
-		ConfGaurun.Ios.PemKeyPath,
-	)
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func enqueueNotifications(notifications []RequestGaurunNotification) {


### PR DESCRIPTION
`http.Transport.IdleConnTimeout` was introduced in Go1.7.
This value is used as an expiration time for an idling connection.

And fixed mistaken handling bug of `(ios|android).keepalive_timeout` previously.