### PR TITLE
[WIP]switched to FCM.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -6,7 +6,7 @@ imports:
 - name: github.com/fukata/golang-stats-api-handler
   version: e7ee1630fdb679c86ec8e3d0755e3576675fdb10
 - name: github.com/mercari/gcm
-  version: 987b1dc4ce9034b698395d35de1aadf999388b8f
+  version: 568b0c4e936fc20627070365549307dc1e976c34
 - name: github.com/RobotsAndPencils/buford
   version: 1589c179b764ddceb204a439d9bf366f04c55f9b
   subpackages:


### PR DESCRIPTION
[FCM](https://firebase.google.com/docs/cloud-messaging/) is the new version of [GCM](https://developers.google.com/cloud-messaging/).