### PR TITLE
Enabled startup without ssl certificate and key for APNs.

### DIFF
--- a/cmd/gaurun/gaurun.go
+++ b/cmd/gaurun/gaurun.go
@@ -99,8 +99,13 @@ func main() {
 
 	go signalHandler(sigChan, sighupHandler)
 
-	if err := gaurun.InitHttpClient(); err != nil {
-		gaurun.LogSetupFatal(fmt.Errorf("failed to init http client"))
+	if gaurun.ConfGaurun.Android.Enabled {
+		gaurun.InitGCMClient()
+	}
+	if gaurun.ConfGaurun.Ios.Enabled {
+		if err := gaurun.InitAPNSClient(); err != nil {
+			gaurun.LogSetupFatal(fmt.Errorf("failed to init http client"))
+		}
 	}
 	gaurun.InitStat()
 	gaurun.StartPushWorkers(gaurun.ConfGaurun.Core.WorkerNum, gaurun.ConfGaurun.Core.QueueNum)

--- a/gaurun/client.go
+++ b/gaurun/client.go
@@ -24,7 +24,7 @@ func keepAliveInterval(keepAliveTimeout int) int {
 	return result
 }
 
-func InitHttpClient() error {
+func InitGCMClient() {
 	TransportGCM := &http.Transport{
 		MaxIdleConnsPerHost: ConfGaurun.Android.KeepAliveConns,
 		Dial: (&net.Dialer{
@@ -40,7 +40,9 @@ func InitHttpClient() error {
 			Timeout:   time.Duration(ConfGaurun.Android.Timeout) * time.Second,
 		},
 	}
+}
 
+func InitAPNSClient() error {
 	var err error
 	APNSClient, err = NewApnsClientHttp2(
 		ConfGaurun.Ios.PemCertPath,

--- a/gaurun/client_test.go
+++ b/gaurun/client_test.go
@@ -1,8 +1,9 @@
 package gaurun
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestKeepAliveInterval(t *testing.T) {

--- a/gaurun/const.go
+++ b/gaurun/const.go
@@ -13,4 +13,5 @@ const (
 	StatusAcceptedPush  = "accepted-push"
 	StatusSucceededPush = "succeeded-push"
 	StatusFailedPush    = "failed-push"
+	StatusDisabledPush  = "disabled-push"
 )

--- a/gaurun/log.go
+++ b/gaurun/log.go
@@ -114,6 +114,8 @@ func LogPush(id uint64, status, token string, ptime float64, req RequestGaurunNo
 	case StatusSucceededPush:
 		logger = LogAccess.Info
 	case StatusFailedPush:
+		fallthrough
+	case StatusDisabledPush:
 		logger = LogError.Error
 	}
 

--- a/gaurun/notification.go
+++ b/gaurun/notification.go
@@ -67,14 +67,16 @@ func enqueueNotifications(notifications []RequestGaurunNotification) {
 		case PlatFormAndroid:
 			enabledPush = ConfGaurun.Android.Enabled
 		}
-		if enabledPush {
-			// Enqueue notification per token
-			for _, token := range notification.Tokens {
-				notification2 := notification
-				notification2.Tokens = []string{token}
-				notification2.ID = numberingPush()
+		// Enqueue notification per token
+		for _, token := range notification.Tokens {
+			notification2 := notification
+			notification2.Tokens = []string{token}
+			notification2.ID = numberingPush()
+			if enabledPush {
 				LogPush(notification2.ID, StatusAcceptedPush, token, 0, notification2, nil)
 				QueueNotification <- notification2
+			} else {
+				LogPush(notification2.ID, StatusDisabledPush, token, 0, notification2, nil)
 			}
 		}
 	}


### PR DESCRIPTION
Previously, gaurun could not start without ssl certificate and key for APNs even if target application is only Android.
