### PR TITLE
Include err of init http client to log

### DIFF
--- a/cmd/gaurun/gaurun.go
+++ b/cmd/gaurun/gaurun.go
@@ -107,7 +107,7 @@ func main() {
 	}
 	if gaurun.ConfGaurun.Ios.Enabled {
 		if err := gaurun.InitAPNSClient(); err != nil {
-			gaurun.LogSetupFatal(fmt.Errorf("failed to init http client: %v", err))
+			gaurun.LogSetupFatal(fmt.Errorf("failed to init http client for APNs: %v", err))
 		}
 	}
 	gaurun.InitStat()

--- a/cmd/gaurun/gaurun.go
+++ b/cmd/gaurun/gaurun.go
@@ -107,7 +107,7 @@ func main() {
 	}
 	if gaurun.ConfGaurun.Ios.Enabled {
 		if err := gaurun.InitAPNSClient(); err != nil {
-			gaurun.LogSetupFatal(fmt.Errorf("failed to init http client"))
+			gaurun.LogSetupFatal(fmt.Errorf("failed to init http client: %v", err))
 		}
 	}
 	gaurun.InitStat()


### PR DESCRIPTION
The error message `failed to init http client` is difficult to understand what's going on.
