### PR TITLE
WIP: Support FCM

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -46,6 +46,7 @@ The configuration for Gaurun has some sections. The example is [here](conf/gauru
 |keepalive_timeout|int   |time for continuing keep-alive connection to GCM|90     |    |
 |keepalive_conns  |int   |number of keep-alive connection to GCM          |runtime.NumCPU()||
 |retry_max        |int   |maximum retry count for push notication to GCM  |1      |    |
+|use_fcm          |bool  |Use FCM endpoint instead of GCM (by default, `gaurun` uses GCM endpoint)  |1      |    |
 
 ## Log Section
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 <img src="https://raw.githubusercontent.com/mercari/gaurun/master/img/logo.png" alt="logo" align="right"/>
 
 
-Gaurun is a general push notification server written in Golang. It proxies push requests to APNs and GCM and asynchronously executes them via HTTP/2. It helps you when you need to bulkly sends push notification to your users (e.g., when you need to exec 10 million push at once!) or when some other API server which must response quickly needs to push. Since it leverages Golang's powerful concurrent feature, it gives high performance. 
+Gaurun is a general push notification server written in Golang. It proxies push requests to APNs and GCM/FCM and asynchronously executes them via HTTP/2. It helps you when you need to bulkly sends push notification to your users (e.g., when you need to exec 10 million push at once!) or when some other API server which must response quickly needs to push. Since it leverages Golang's powerful concurrent feature, it gives high performance. 
 
 In addition to performance, it's important not to lost pushes over sever crashes or hardware failures. Gaurun can use its access log for kind of transaction journal and can re-push only failed notification later (We provide a special command for this. See [Usage](#usage)). 
 
 Currently we support the following platforms:
 
 - [Apple APNs](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html)
-- [Google GCM](https://developers.google.com/cloud-messaging/)
+- [Google GCM](https://developers.google.com/cloud-messaging/) / [Google FCM](https://firebase.google.com/docs/cloud-messaging/)
 
 ## Status
 

--- a/conf/gaurun.toml
+++ b/conf/gaurun.toml
@@ -13,6 +13,7 @@ timeout = 5 # sec
 keepalive_timeout = 30
 keepalive_conns = 4
 retry_max = 1
+use_fcm = true
 
 [ios]
 pem_cert_path = "cert.pem"

--- a/gaurun/client.go
+++ b/gaurun/client.go
@@ -25,6 +25,13 @@ func keepAliveInterval(keepAliveTimeout int) int {
 }
 
 func InitGCMClient() {
+	// By default, use GCM endpoint. If UseFCM is explicitly enabled via configuration,
+	// use FCM endpoint.
+	GCMClient, _ := gcm.NewClient(gcm.GcmSendEndpoint, ConfGaurun.Android.ApiKey)
+	if ConfGaurun.Android.UseFCM {
+		GCMClient, _ = gcm.NewClient(gcm.FCMSendEndpoint, ConfGaurun.Android.ApiKey)
+	}
+
 	TransportGCM := &http.Transport{
 		MaxIdleConnsPerHost: ConfGaurun.Android.KeepAliveConns,
 		Dial: (&net.Dialer{
@@ -33,12 +40,10 @@ func InitGCMClient() {
 		}).Dial,
 		IdleConnTimeout: time.Duration(ConfGaurun.Android.KeepAliveTimeout) * time.Second,
 	}
-	GCMClient = &gcm.Sender{
-		ApiKey: ConfGaurun.Android.ApiKey,
-		Http: &http.Client{
-			Transport: TransportGCM,
-			Timeout:   time.Duration(ConfGaurun.Android.Timeout) * time.Second,
-		},
+
+	GCMClient.Http = &http.Client{
+		Transport: TransportGCM,
+		Timeout:   time.Duration(ConfGaurun.Android.Timeout) * time.Second,
 	}
 }
 

--- a/gaurun/conf.go
+++ b/gaurun/conf.go
@@ -35,6 +35,7 @@ type SectionAndroid struct {
 	KeepAliveTimeout int    `toml:"keepalive_timeout"`
 	KeepAliveConns   int    `toml:"keepalive_conns"`
 	RetryMax         int    `toml:"retry_max"`
+	UseFCM           bool   `toml:"use_fcm"`
 }
 
 type SectionIos struct {

--- a/gaurun/conf_test.go
+++ b/gaurun/conf_test.go
@@ -43,6 +43,7 @@ func (suite *ConfigTestSuite) TestValidateConfDefault() {
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.KeepAliveTimeout, 90)
 	assert.Equal(suite.T(), int64(suite.ConfGaurunDefault.Android.KeepAliveConns), suite.ConfGaurunDefault.Core.WorkerNum)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.RetryMax, 1)
+	assert.Equal(suite.T(), suite.ConfGaurunDefault.Android.UseFCM, false)
 	// Ios
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.Enabled, true)
 	assert.Equal(suite.T(), suite.ConfGaurunDefault.Ios.PemCertPath, "")
@@ -73,6 +74,7 @@ func (suite *ConfigTestSuite) TestValidateConf() {
 	assert.Equal(suite.T(), suite.ConfGaurun.Android.KeepAliveTimeout, 30)
 	assert.Equal(suite.T(), suite.ConfGaurun.Android.KeepAliveConns, 4)
 	assert.Equal(suite.T(), suite.ConfGaurun.Android.RetryMax, 1)
+	assert.Equal(suite.T(), suite.ConfGaurun.Android.UseFCM, true)
 	// Ios
 	assert.Equal(suite.T(), suite.ConfGaurun.Ios.Enabled, true)
 	assert.Equal(suite.T(), suite.ConfGaurun.Ios.PemCertPath, "cert.pem")

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 079a45997e1687b1af2ffa25fcf4fd0377f5b2b0a42886079c63a89bb2401d78
-updated: 2017-03-01T14:02:52.14659913+09:00
+hash: 3ce8390ae32204a39c07485af094567cfb82ea347a76b59a7a0f0196f1f652ae
+updated: 2017-03-13T17:40:52.258637752+09:00
 imports:
 - name: github.com/BurntSushi/toml
   version: bbd5bb678321a0d6e58f1099321dfa73391c1b6f
@@ -12,7 +12,7 @@ imports:
   subpackages:
   - listener
 - name: github.com/mercari/gcm
-  version: 987b1dc4ce9034b698395d35de1aadf999388b8f
+  version: a30cd8c437aa08cd620f8fec0cbdc8928097014b
 - name: github.com/RobotsAndPencils/buford
   version: 1589c179b764ddceb204a439d9bf366f04c55f9b
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,6 +9,7 @@ import:
   - payload/badge
   - push
 - package: github.com/mercari/gcm
+  version: feature/fcm
 - package: github.com/fukata/golang-stats-api-handler
 - package: github.com/stretchr/testify
 - package: github.com/client9/reopen


### PR DESCRIPTION
After https://github.com/mercari/gcm/pull/3 is merged, we can switch GCM/FCM endpoint when initializing a client (sender). This PR enables to use FCM endpoint when `use_fcm` is `true` via configuration (by default, continue to use GCM). 