### PR TITLE
Support APNs payload extensions for `Title & Subtitle`

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,6 +27,8 @@ The JSON below is the request-body example.
             "token" : ["xxx"],
             "platform" : 1,
             "message" : "Hello, iOS!",
+            "title": "Greeting",
+            "subtitle": "greeting",
             "badge" : 1,
             "sound" : "default",
             "content_available" : false,
@@ -37,9 +39,7 @@ The JSON below is the request-body example.
         {
             "token" : ["yyy"],
             "platform" : 2,
-            "title": "Greeting",
             "message" : "Hello, Android!",
-            "subtitle": "greeting",
             "collapse_key" : "update",
             "delay_while_idle" : true,
             "time_to_live" : 10
@@ -54,9 +54,9 @@ The request-body must has the `notifications` array. There is the parameter tabl
 |-----------------|------------|-----------------------------------------|--------|-------|----------------|
 |token            |string array|device tokens                            |o       |       |                |
 |platform         |int         |platform(iOS,Android)                    |o       |       |1=iOS, 2=Android|
-|title            |string      |title for notification                   |o       |       |only iOS        |
 |message          |string      |message for notification                 |o       |       |                |
-|subtitle         |string      |subtitle for notification                |o       |       |only iOS        |
+|title            |string      |title for notification                   |-       |       |only iOS        |
+|subtitle         |string      |subtitle for notification                |-       |       |only iOS        |
 |badge            |int         |badge count                              |-       |0      |only iOS        |
 |sound            |string      |sound type                               |-       |       |only iOS        |
 |expiry           |int         |expiration for notification              |-       |0      |only iOS.       |

--- a/SPEC.md
+++ b/SPEC.md
@@ -37,7 +37,9 @@ The JSON below is the request-body example.
         {
             "token" : ["yyy"],
             "platform" : 2,
+            "title": "Greeting",
             "message" : "Hello, Android!",
+            "subtitle": "greeting",
             "collapse_key" : "update",
             "delay_while_idle" : true,
             "time_to_live" : 10
@@ -52,7 +54,9 @@ The request-body must has the `notifications` array. There is the parameter tabl
 |-----------------|------------|-----------------------------------------|--------|-------|----------------|
 |token            |string array|device tokens                            |o       |       |                |
 |platform         |int         |platform(iOS,Android)                    |o       |       |1=iOS, 2=Android|
+|title            |string      |title for notification                   |o       |       |only iOS        |
 |message          |string      |message for notification                 |o       |       |                |
+|subtitle         |string      |subtitle for notification                |o       |       |only iOS        |
 |badge            |int         |badge count                              |-       |0      |only iOS        |
 |sound            |string      |sound type                               |-       |       |only iOS        |
 |expiry           |int         |expiration for notification              |-       |0      |only iOS.       |

--- a/cmd/gaurun_recover/gaurun_recover.go
+++ b/cmd/gaurun_recover/gaurun_recover.go
@@ -187,6 +187,8 @@ func main() {
 			CollapseKey:      logPush.CollapseKey,
 			DelayWhileIdle:   logPush.DelayWhileIdle,
 			TimeToLive:       logPush.TimeToLive,
+			Title:            logPush.Title,
+			Subtitle:         logPush.Subtitle,
 			Badge:            logPush.Badge,
 			Sound:            logPush.Sound,
 			ContentAvailable: logPush.ContentAvailable,

--- a/gaurun/apns_http2.go
+++ b/gaurun/apns_http2.go
@@ -69,7 +69,7 @@ func NewApnsServiceHttp2(client *http.Client) *push.Service {
 
 func NewApnsPayloadHttp2(req *RequestGaurunNotification) map[string]interface{} {
 	p := payload.APS{
-		Alert:            payload.Alert{Body: req.Message},
+		Alert:            payload.Alert{Title: req.Title, Body: req.Message, Subtitle: req.Subtitle},
 		Badge:            badge.New(uint(req.Badge)),
 		Sound:            req.Sound,
 		ContentAvailable: req.ContentAvailable,

--- a/gaurun/log.go
+++ b/gaurun/log.go
@@ -35,6 +35,8 @@ type LogPushEntry struct {
 	DelayWhileIdle bool   `json:"delay_while_idle,omitempty"`
 	TimeToLive     int    `json:"time_to_live,omitempty"`
 	// iOS
+	Title            string `json:"title,omitempty"`
+	Subtitle         string `json:"subtitle,omitempty"`
 	Badge            int    `json:"badge,omitempty"`
 	Sound            string `json:"sound,omitempty"`
 	ContentAvailable bool   `json:"content_available,omitempty"`
@@ -147,6 +149,14 @@ func LogPush(id uint64, status, token string, ptime float64, req RequestGaurunNo
 	if req.TimeToLive != 0 {
 		timeToLive = zap.Int("time_to_live", req.TimeToLive)
 	}
+	title := zap.Skip()
+	if req.Title != "" {
+		title = zap.String("title", req.Title)
+	}
+	subtitle := zap.Skip()
+	if req.Subtitle != "" {
+		subtitle = zap.String("subtitle", req.Subtitle)
+	}
 	badge := zap.Skip()
 	if req.Badge != 0 {
 		badge = zap.Int("badge", req.Badge)
@@ -178,6 +188,8 @@ func LogPush(id uint64, status, token string, ptime float64, req RequestGaurunNo
 		collapseKey,
 		delayWhileIdle,
 		timeToLive,
+		title,
+		subtitle,
 		badge,
 		sound,
 		contentAvailable,

--- a/gaurun/notification.go
+++ b/gaurun/notification.go
@@ -29,6 +29,8 @@ type RequestGaurunNotification struct {
 	DelayWhileIdle bool   `json:"delay_while_idle,omitempty"`
 	TimeToLive     int    `json:"time_to_live,omitempty"`
 	// iOS
+	Title            string       `json:"title,omitempty"`
+	Subtitle         string       `json:"subtitle,omitempty"`
 	Badge            int          `json:"badge,omitempty"`
 	Sound            string       `json:"sound,omitempty"`
 	ContentAvailable bool         `json:"content_available,omitempty"`

--- a/samples/client.go
+++ b/samples/client.go
@@ -59,8 +59,8 @@ func main() {
 	if *iOSToken != "" {
 		req.Notifications[i].Tokens = append(req.Notifications[i].Tokens, *iOSToken)
 		req.Notifications[i].Platform = 1
-		req.Notifications[i].Title = "Greeting"
 		req.Notifications[i].Message = "Hello, iOS!"
+		req.Notifications[i].Title = "Greeting"
 		req.Notifications[i].Subtitle = "greeting"
 		req.Notifications[i].Badge = 1
 		req.Notifications[i].Sound = "default"

--- a/samples/client.go
+++ b/samples/client.go
@@ -24,6 +24,8 @@ type RequestGaurunNotification struct {
 	DelayWhileIdle bool   `json:"data_while_idle"`
 	TimeToLive     int    `json:"time_to_live"`
 	// iOS
+	Title            string `json:"title"`
+	Subtitle         string `json:"subtitle"`
 	Badge            int    `json:"badge"`
 	Sound            string `json:"sound"`
 	ContentAvailable bool   `json:"content_available"`
@@ -57,7 +59,9 @@ func main() {
 	if *iOSToken != "" {
 		req.Notifications[i].Tokens = append(req.Notifications[i].Tokens, *iOSToken)
 		req.Notifications[i].Platform = 1
+		req.Notifications[i].Title = "Greeting"
 		req.Notifications[i].Message = "Hello, iOS!"
+		req.Notifications[i].Subtitle = "greeting"
 		req.Notifications[i].Badge = 1
 		req.Notifications[i].Sound = "default"
 		req.Notifications[i].ContentAvailable = true


### PR DESCRIPTION
This PR allows to send `Title` and `Subtitle` with an existing payload.

From iOS ver10, it supports Bold-styled title and subtitles to display rich notifications.
