### PR TITLE
Add UNNotificationCategory option for iOS. 

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -30,6 +30,7 @@ The JSON below is the request-body example.
             "title": "Greeting",
             "subtitle": "greeting",
             "badge" : 1,
+            "category": "category1",
             "sound" : "default",
             "content_available" : false,
             "mutable_content" : false,
@@ -58,6 +59,7 @@ The request-body must has the `notifications` array. There is the parameter tabl
 |title            |string      |title for notification                   |-       |       |only iOS        |
 |subtitle         |string      |subtitle for notification                |-       |       |only iOS        |
 |badge            |int         |badge count                              |-       |0      |only iOS        |
+|category         |string      |unnotification category                  |-       |       |only iOS        |
 |sound            |string      |sound type                               |-       |       |only iOS        |
 |expiry           |int         |expiration for notification              |-       |0      |only iOS.       |
 |content_available|bool        |indicate that new content is available   |-       |false  |only iOS.       |

--- a/cmd/gaurun_recover/gaurun_recover.go
+++ b/cmd/gaurun_recover/gaurun_recover.go
@@ -190,6 +190,7 @@ func main() {
 			Title:            logPush.Title,
 			Subtitle:         logPush.Subtitle,
 			Badge:            logPush.Badge,
+			Category:         logPush.Category,
 			Sound:            logPush.Sound,
 			ContentAvailable: logPush.ContentAvailable,
 			Expiry:           logPush.Expiry,

--- a/gaurun/apns_http2.go
+++ b/gaurun/apns_http2.go
@@ -71,6 +71,7 @@ func NewApnsPayloadHttp2(req *RequestGaurunNotification) map[string]interface{} 
 	p := payload.APS{
 		Alert:            payload.Alert{Title: req.Title, Body: req.Message, Subtitle: req.Subtitle},
 		Badge:            badge.New(uint(req.Badge)),
+		Category:         req.Category,
 		Sound:            req.Sound,
 		ContentAvailable: req.ContentAvailable,
 		MutableContent:   req.MutableContent,

--- a/gaurun/log.go
+++ b/gaurun/log.go
@@ -38,6 +38,7 @@ type LogPushEntry struct {
 	Title            string `json:"title,omitempty"`
 	Subtitle         string `json:"subtitle,omitempty"`
 	Badge            int    `json:"badge,omitempty"`
+	Category         string `json:"category,omitempty"`
 	Sound            string `json:"sound,omitempty"`
 	ContentAvailable bool   `json:"content_available,omitempty"`
 	MutableContent   bool   `json:"mutable_content,omitempty"`
@@ -161,6 +162,10 @@ func LogPush(id uint64, status, token string, ptime float64, req RequestGaurunNo
 	if req.Badge != 0 {
 		badge = zap.Int("badge", req.Badge)
 	}
+	category := zap.Skip()
+	if req.Category != "" {
+		category = zap.String("category", req.Category)
+	}
 	sound := zap.Skip()
 	if req.Sound != "" {
 		sound = zap.String("sound", req.Sound)
@@ -191,6 +196,7 @@ func LogPush(id uint64, status, token string, ptime float64, req RequestGaurunNo
 		title,
 		subtitle,
 		badge,
+		category,
 		sound,
 		contentAvailable,
 		mutableContent,

--- a/gaurun/notification.go
+++ b/gaurun/notification.go
@@ -32,6 +32,7 @@ type RequestGaurunNotification struct {
 	Title            string       `json:"title,omitempty"`
 	Subtitle         string       `json:"subtitle,omitempty"`
 	Badge            int          `json:"badge,omitempty"`
+	Category         string       `json:"category,omitempty"`
 	Sound            string       `json:"sound,omitempty"`
 	ContentAvailable bool         `json:"content_available,omitempty"`
 	MutableContent   bool         `json:"mutable_content,omitempty"`

--- a/samples/client.go
+++ b/samples/client.go
@@ -27,6 +27,7 @@ type RequestGaurunNotification struct {
 	Title            string `json:"title"`
 	Subtitle         string `json:"subtitle"`
 	Badge            int    `json:"badge"`
+	Category         string `json:"category"`
 	Sound            string `json:"sound"`
 	ContentAvailable bool   `json:"content_available"`
 	Expiry           int    `json:"expiry"`
@@ -63,6 +64,7 @@ func main() {
 		req.Notifications[i].Title = "Greeting"
 		req.Notifications[i].Subtitle = "greeting"
 		req.Notifications[i].Badge = 1
+		req.Notifications[i].Category = "category1"
 		req.Notifications[i].Sound = "default"
 		req.Notifications[i].ContentAvailable = true
 		i++


### PR DESCRIPTION
This commit will enable `unnotificationcategory` for iOS.
https://developer.apple.com/documentation/usernotifications/unnotificationcategory

It'll categorize notifications if a user chose not to display preview of notifications on setting.
And it'll also let you to handle actions that depends on categories.