### PR TITLE
bugfix: set Content-Type: application/json; charset=utf-8 for json response.

### DIFF
--- a/gaurun/notification.go
+++ b/gaurun/notification.go
@@ -187,10 +187,10 @@ func sendResponse(w http.ResponseWriter, msg string, code int) {
 		buf = bytes.NewBufferString("{\"message\":\"Response-body could not be created\"}")
 	}
 
-	w.WriteHeader(code)
-
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.Header().Set("Server", serverHeader())
+
+	w.WriteHeader(code)
 
 	w.Write(buf.Bytes())
 }


### PR DESCRIPTION
Previously, Gaurun returned response with the header of `Content-Type: text/plain` even if response body is json. 

This was caused by the execution order of `http.ResponseWriter` functions. `w.Header().Set(key, val)` must be called before `WriteHeader(code)`. Otherwise, response header is not set.
