### PR TITLE
Add parameter for tracking each request in the log

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -50,23 +50,24 @@ The JSON below is the request-body example.
 
 The request-body must has the `notifications` array. There is the parameter table for each notification below.
 
-|name             |type        |description                              |required|default|note            |
-|-----------------|------------|-----------------------------------------|--------|-------|----------------|
-|token            |string array|device tokens                            |o       |       |                |
-|platform         |int         |platform(iOS,Android)                    |o       |       |1=iOS, 2=Android|
-|message          |string      |message for notification                 |o       |       |                |
-|title            |string      |title for notification                   |-       |       |only iOS        |
-|subtitle         |string      |subtitle for notification                |-       |       |only iOS        |
-|badge            |int         |badge count                              |-       |0      |only iOS        |
-|category         |string      |unnotification category                  |-       |       |only iOS        |
-|sound            |string      |sound type                               |-       |       |only iOS        |
-|expiry           |int         |expiration for notification              |-       |0      |only iOS.       |
-|content_available|bool        |indicate that new content is available   |-       |false  |only iOS.       |
-|mutable_content  |bool        |enable Notification Service app extension|-       |false  |only iOS(10.0+).|
-|collapse_key     |string      |the key for collapsing notifications     |-       |       |only Android    |
-|delay_while_idle |bool        |the flag for device idling               |-       |false  |only Android    |
-|time_to_live     |int         |expiration of message kept on GCM storage|-       |0      |only Android    |
-|extend           |string array|extensible partition                     |-       |       |                |
+|name             |type        |description                              |required|default|note                                      |
+|-----------------|------------|-----------------------------------------|--------|-------|------------------------------------------|
+|token            |string array|device tokens                            |o       |       |                                          |
+|platform         |int         |platform(iOS,Android)                    |o       |       |1=iOS, 2=Android                          |
+|message          |string      |message for notification                 |o       |       |                                          |
+|title            |string      |title for notification                   |-       |       |only iOS                                  |
+|subtitle         |string      |subtitle for notification                |-       |       |only iOS                                  |
+|badge            |int         |badge count                              |-       |0      |only iOS                                  |
+|category         |string      |unnotification category                  |-       |       |only iOS                                  |
+|sound            |string      |sound type                               |-       |       |only iOS                                  |
+|expiry           |int         |expiration for notification              |-       |0      |only iOS.                                 |
+|content_available|bool        |indicate that new content is available   |-       |false  |only iOS.                                 |
+|mutable_content  |bool        |enable Notification Service app extension|-       |false  |only iOS(10.0+).                          |
+|collapse_key     |string      |the key for collapsing notifications     |-       |       |only Android                              |
+|delay_while_idle |bool        |the flag for device idling               |-       |false  |only Android                              |
+|time_to_live     |int         |expiration of message kept on GCM storage|-       |0      |only Android                              |
+|extend           |string array|extensible partition                     |-       |       |                                          |
+|identifier       |string      |notification identifier                  |-       |       |an optional value to identify notification|
 
 The JSON below is the response-body example from Gaurun. In this case, the status is 200(OK).
 

--- a/gaurun/log.go
+++ b/gaurun/log.go
@@ -137,7 +137,7 @@ func LogPush(id uint64, status, token string, ptime float64, req RequestGaurunNo
 		logger = LogError.Error
 	}
 
-	// omitempty handling for device dependent values
+	// omitempty request parameters handling.
 	collapseKey := zap.Skip()
 	if req.CollapseKey != "" {
 		collapseKey = zap.String("collapse_key", req.CollapseKey)
@@ -182,6 +182,10 @@ func LogPush(id uint64, status, token string, ptime float64, req RequestGaurunNo
 	if req.Expiry != 0 {
 		expiry = zap.Int("expiry", req.Expiry)
 	}
+	identifier := zap.Skip()
+	if req.Identifier != "" {
+		identifier = zap.String("identifier", req.Identifier)
+	}
 
 	logger(req.Message,
 		zap.Uint64("id", id),
@@ -201,6 +205,7 @@ func LogPush(id uint64, status, token string, ptime float64, req RequestGaurunNo
 		contentAvailable,
 		mutableContent,
 		expiry,
+		identifier,
 	)
 }
 

--- a/gaurun/notification.go
+++ b/gaurun/notification.go
@@ -21,9 +21,10 @@ type RequestGaurun struct {
 
 type RequestGaurunNotification struct {
 	// Common
-	Tokens   []string `json:"token"`
-	Platform int      `json:"platform"`
-	Message  string   `json:"message"`
+	Tokens     []string `json:"token"`
+	Platform   int      `json:"platform"`
+	Message    string   `json:"message"`
+	Identifier string   `json:"identifier,omitempty"`
 	// Android
 	CollapseKey    string `json:"collapse_key,omitempty"`
 	DelayWhileIdle bool   `json:"delay_while_idle,omitempty"`

--- a/gaurun/notification_test.go
+++ b/gaurun/notification_test.go
@@ -32,6 +32,15 @@ func TestValidateNotification(t *testing.T) {
 			},
 			nil,
 		},
+		{
+			RequestGaurunNotification{
+				Tokens:     []string{"test token"},
+				Platform:   1,
+				Message:    "test message with identifier",
+				Identifier: "identifier",
+			},
+			nil,
+		},
 
 		// negative cases
 		{


### PR DESCRIPTION
## Background

Sometimes we cannot send the notification to iOS/Android clients. For example, when the notification is expired.

I want to get the correspondence between the requests to Gaurun and the logs recorded by Gaurun. It helps us to investigate the reason why the notification was not delivered to the client.

## What I did

* Add `TrackingID` parameter to `gaurun.RequestGaurunNotification`
* Enable `gaurun.LogPush` to store the `TrackingID` when it is given

## When this pull request is merged

* We can give `tracking_id` to `notification` parameter for Gaurun `/push` request
* We can see `tracking_id` in the push log stored by Gaurun
