### PR TITLE
Support thread-id available in iOS 12

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -34,6 +34,7 @@ The JSON below is the request-body example.
             "content_available" : false,
             "mutable_content" : false,
             "expiry" : 10,
+            "thread_id" : "thread_id",
             "extend" : [{ "key": "url", "val": "..." }, { "key": "intent", "val": "..." }]
         },
         {
@@ -62,6 +63,7 @@ The request-body must has the `notifications` array. There is the parameter tabl
 |sound            |string      |sound type                               |-       |       |only iOS                                  |
 |expiry           |int         |expiration for notification              |-       |0      |only iOS.                                 |
 |content_available|bool        |indicate that new content is available   |-       |false  |only iOS.                                 |
+|thread_id        |string      |to group your notifications together     |-       |       |only iOS.                                 |
 |mutable_content  |bool        |enable Notification Service app extension|-       |false  |only iOS(10.0+).                          |
 |collapse_key     |string      |the key for collapsing notifications     |-       |       |only Android                              |
 |delay_while_idle |bool        |the flag for device idling               |-       |false  |only Android                              |

--- a/cmd/gaurun_recover/gaurun_recover.go
+++ b/cmd/gaurun_recover/gaurun_recover.go
@@ -191,6 +191,7 @@ func main() {
 			Sound:            logPush.Sound,
 			ContentAvailable: logPush.ContentAvailable,
 			Expiry:           logPush.Expiry,
+			ThreadID:         logPush.ThreadID,
 		}
 		wg.Add(1)
 		go pushNotification(wg, req, logPush)

--- a/gaurun/apns_http2.go
+++ b/gaurun/apns_http2.go
@@ -107,6 +107,7 @@ func NewApnsPayloadHttp2(req *RequestGaurunNotification) map[string]interface{} 
 		Sound:            req.Sound,
 		ContentAvailable: req.ContentAvailable,
 		MutableContent:   req.MutableContent,
+		ThreadID:         req.ThreadID,
 	}
 
 	pm := p.Map()

--- a/gaurun/log.go
+++ b/gaurun/log.go
@@ -43,6 +43,7 @@ type LogPushEntry struct {
 	ContentAvailable bool   `json:"content_available,omitempty"`
 	MutableContent   bool   `json:"mutable_content,omitempty"`
 	Expiry           int    `json:"expiry,omitempty"`
+	ThreadID         string `json:"thread_id,omitempty"`
 }
 
 type Reopener interface {
@@ -182,6 +183,10 @@ func LogPush(id uint64, status, token string, ptime float64, req RequestGaurunNo
 	if req.Expiry != 0 {
 		expiry = zap.Int("expiry", req.Expiry)
 	}
+	threadID := zap.Skip()
+	if req.ThreadID != "" {
+		threadID = zap.String("thread_id", req.ThreadID)
+	}
 	identifier := zap.Skip()
 	if req.Identifier != "" {
 		identifier = zap.String("identifier", req.Identifier)
@@ -205,6 +210,7 @@ func LogPush(id uint64, status, token string, ptime float64, req RequestGaurunNo
 		contentAvailable,
 		mutableContent,
 		expiry,
+		threadID,
 		identifier,
 	)
 }

--- a/gaurun/notification.go
+++ b/gaurun/notification.go
@@ -40,6 +40,7 @@ type RequestGaurunNotification struct {
 	Expiry           int          `json:"expiry,omitempty"`
 	Retry            int          `json:"retry,omitempty"`
 	Extend           []ExtendJSON `json:"extend,omitempty"`
+	ThreadID         string       `json:"thread_id,omitempty"`
 	// meta
 	ID uint64 `json:"seq_id,omitempty"`
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/mercari/gaurun
 
 require (
 	github.com/BurntSushi/toml v0.2.0
-	github.com/RobotsAndPencils/buford v0.12.1-0.20190121232938-75d85f30d5ff
+	github.com/RobotsAndPencils/buford v0.13.0
 	github.com/client9/reopen v0.0.0-20160619053521-4b86f9c0ead5
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fukata/golang-stats-api-handler v0.0.0-20160325105040-ab9f90f16caa

--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,16 @@ module github.com/mercari/gaurun
 
 require (
 	github.com/BurntSushi/toml v0.2.0
-	github.com/RobotsAndPencils/buford v0.12.0
+	github.com/RobotsAndPencils/buford v0.12.1-0.20190121232938-75d85f30d5ff
 	github.com/client9/reopen v0.0.0-20160619053521-4b86f9c0ead5
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fukata/golang-stats-api-handler v0.0.0-20160325105040-ab9f90f16caa
 	github.com/lestrrat/go-server-starter v0.0.0-20151125041704-901cec093d58
+	github.com/pkg/errors v0.8.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312
-	go.uber.org/atomic v1.1.0
+	go.uber.org/atomic v1.1.0 // indirect
 	go.uber.org/zap v0.0.0-20170224221842-12592ca48efc
+	golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc // indirect
 	golang.org/x/net v0.0.0-20161116075034-4971afdc2f16
 )

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,6 @@ require (
 	github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312
 	go.uber.org/atomic v1.1.0 // indirect
 	go.uber.org/zap v0.0.0-20170224221842-12592ca48efc
-	golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc // indirect
+	golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613 // indirect
 	golang.org/x/net v0.0.0-20161116075034-4971afdc2f16
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/BurntSushi/toml v0.2.0 h1:OthAm9ZSUx4uAmn3WbPwc06nowWrByRwBsYRhbmFjBs
 github.com/BurntSushi/toml v0.2.0/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/RobotsAndPencils/buford v0.12.0 h1:2nfOk+N/QVoQHwXIS0m5TFdvlUjEnqAj/0yXKR75azY=
 github.com/RobotsAndPencils/buford v0.12.0/go.mod h1:27KhJZ/wLQHRnsZF+mTWKvF5w8U4dVl4Nh+BfQem4Lo=
+github.com/RobotsAndPencils/buford v0.12.1-0.20190121232938-75d85f30d5ff h1:A2fNCj9bZXAlAJWewqeGD9nxKp6s8WdFD2lfkHSUeNE=
+github.com/RobotsAndPencils/buford v0.12.1-0.20190121232938-75d85f30d5ff/go.mod h1:27KhJZ/wLQHRnsZF+mTWKvF5w8U4dVl4Nh+BfQem4Lo=
 github.com/client9/reopen v0.0.0-20160619053521-4b86f9c0ead5 h1:46QA9E5dIKm6lNygBd+eSiLF32HsgjJwbA1IELhs5Vo=
 github.com/client9/reopen v0.0.0-20160619053521-4b86f9c0ead5/go.mod h1:caXVCEr+lUtoN1FlsRiOWdfQtdRHIYfcb0ai8qKWtkQ=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -10,6 +12,8 @@ github.com/fukata/golang-stats-api-handler v0.0.0-20160325105040-ab9f90f16caa h1
 github.com/fukata/golang-stats-api-handler v0.0.0-20160325105040-ab9f90f16caa/go.mod h1:1sIi4/rHq6s/ednWMZqTmRq3765qTUSs/c3xF6lj8J8=
 github.com/lestrrat/go-server-starter v0.0.0-20151125041704-901cec093d58 h1:9/ngkqJb42WLtYR6EFRnImztkmF+n5EhwKBxVOj2B3o=
 github.com/lestrrat/go-server-starter v0.0.0-20151125041704-901cec093d58/go.mod h1:3T+o9dIpjId0dpv2Aa7+HivBIW9h9nra0VuN5ARP/ec=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312 h1:UsFdQ3ZmlzS0BqZYGxvYaXvFGUbCmPGy8DM7qWJJiIQ=
@@ -18,5 +22,7 @@ go.uber.org/atomic v1.1.0 h1:wm63V2eSi29VDCF8+5+V0ruTF+GgWT9cW/J9mpkPtRo=
 go.uber.org/atomic v1.1.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/zap v0.0.0-20170224221842-12592ca48efc h1:pt7EHxvttVwmn5rrlkwEFkjs4OYEOvbLrQgfrNlHTAY=
 go.uber.org/zap v0.0.0-20170224221842-12592ca48efc/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
+golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc h1:F5tKCVGp+MUAHhKp5MZtGqAlGX3+oCsiL1Q629FL90M=
+golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20161116075034-4971afdc2f16 h1:x2xFZACPoDbV+g+48fDH/4EQTTNPgHTRko7g0JQiZws=
 golang.org/x/net v0.0.0-20161116075034-4971afdc2f16/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v0.2.0 h1:OthAm9ZSUx4uAmn3WbPwc06nowWrByRwBsYRhbmFjBs=
 github.com/BurntSushi/toml v0.2.0/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/RobotsAndPencils/buford v0.12.1-0.20190121232938-75d85f30d5ff h1:A2fNCj9bZXAlAJWewqeGD9nxKp6s8WdFD2lfkHSUeNE=
-github.com/RobotsAndPencils/buford v0.12.1-0.20190121232938-75d85f30d5ff/go.mod h1:27KhJZ/wLQHRnsZF+mTWKvF5w8U4dVl4Nh+BfQem4Lo=
+github.com/RobotsAndPencils/buford v0.13.0 h1:hFgGnYmZNrSOMsJPEOwdhrYVR3GTOpOilvLW0/d1aTg=
+github.com/RobotsAndPencils/buford v0.13.0/go.mod h1:27KhJZ/wLQHRnsZF+mTWKvF5w8U4dVl4Nh+BfQem4Lo=
 github.com/client9/reopen v0.0.0-20160619053521-4b86f9c0ead5 h1:46QA9E5dIKm6lNygBd+eSiLF32HsgjJwbA1IELhs5Vo=
 github.com/client9/reopen v0.0.0-20160619053521-4b86f9c0ead5/go.mod h1:caXVCEr+lUtoN1FlsRiOWdfQtdRHIYfcb0ai8qKWtkQ=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/BurntSushi/toml v0.2.0 h1:OthAm9ZSUx4uAmn3WbPwc06nowWrByRwBsYRhbmFjBs=
 github.com/BurntSushi/toml v0.2.0/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/RobotsAndPencils/buford v0.12.0 h1:2nfOk+N/QVoQHwXIS0m5TFdvlUjEnqAj/0yXKR75azY=
-github.com/RobotsAndPencils/buford v0.12.0/go.mod h1:27KhJZ/wLQHRnsZF+mTWKvF5w8U4dVl4Nh+BfQem4Lo=
 github.com/RobotsAndPencils/buford v0.12.1-0.20190121232938-75d85f30d5ff h1:A2fNCj9bZXAlAJWewqeGD9nxKp6s8WdFD2lfkHSUeNE=
 github.com/RobotsAndPencils/buford v0.12.1-0.20190121232938-75d85f30d5ff/go.mod h1:27KhJZ/wLQHRnsZF+mTWKvF5w8U4dVl4Nh+BfQem4Lo=
 github.com/client9/reopen v0.0.0-20160619053521-4b86f9c0ead5 h1:46QA9E5dIKm6lNygBd+eSiLF32HsgjJwbA1IELhs5Vo=
@@ -22,7 +20,7 @@ go.uber.org/atomic v1.1.0 h1:wm63V2eSi29VDCF8+5+V0ruTF+GgWT9cW/J9mpkPtRo=
 go.uber.org/atomic v1.1.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/zap v0.0.0-20170224221842-12592ca48efc h1:pt7EHxvttVwmn5rrlkwEFkjs4OYEOvbLrQgfrNlHTAY=
 go.uber.org/zap v0.0.0-20170224221842-12592ca48efc/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
-golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc h1:F5tKCVGp+MUAHhKp5MZtGqAlGX3+oCsiL1Q629FL90M=
-golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613 h1:MQ/ZZiDsUapFFiMS+vzwXkCTeEKaum+Do5rINYJDmxc=
+golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20161116075034-4971afdc2f16 h1:x2xFZACPoDbV+g+48fDH/4EQTTNPgHTRko7g0JQiZws=
 golang.org/x/net v0.0.0-20161116075034-4971afdc2f16/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/samples/client.go
+++ b/samples/client.go
@@ -31,6 +31,7 @@ type RequestGaurunNotification struct {
 	Sound            string `json:"sound"`
 	ContentAvailable bool   `json:"content_available"`
 	Expiry           int    `json:"expiry"`
+	ThreadID         string `json:"thread_id,omitempty"`
 }
 
 func main() {
@@ -67,6 +68,7 @@ func main() {
 		req.Notifications[i].Category = "category1"
 		req.Notifications[i].Sound = "default"
 		req.Notifications[i].ContentAvailable = true
+		req.Notifications[i].ThreadID = "thread_id"
 		i++
 	}
 


### PR DESCRIPTION
Please read the CLA carefully before submitting your contribution to Mercari.
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.

https://www.mercari.com/cla/

I agreed CLA.

## Changes

- Add `thread-id` available from iOS 12

| thread-id | String | Provide this key with a string value that represents the app-specific identifier for grouping notifications. If you provide a Notification Content app extension, you can use this value to group your notifications together. For local notifications, this key corresponds to the threadIdentifier property of the UNNotificationContent object. |
|-----------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

I used https://github.com/RobotsAndPencils/buford `v0.13.0`.

## References from Apple

* [Using Grouped Notifications - WWDC 2018 - Videos - Apple Developer](https://developer.apple.com/videos/play/wwdc2018/711)
* [Local and Remote Notification Programming Guide: Payload Key Reference](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html#//apple_ref/doc/uid/TP40008194-CH17-SW1)