### PR TITLE
fix to check error

### DIFF
--- a/gaurun/notification.go
+++ b/gaurun/notification.go
@@ -218,8 +218,8 @@ func PushNotificationHandler(w http.ResponseWriter, r *http.Request) {
 	)
 
 	if ConfGaurun.Log.Level == "debug" {
-		reqBody, err := ioutil.ReadAll(r.Body)
-		if err != nil {
+		reqBody, ierr := ioutil.ReadAll(r.Body)
+		if ierr != nil {
 			sendResponse(w, "failed to read request-body", http.StatusInternalServerError)
 			return
 		}


### PR DESCRIPTION
staticcheck says
```
gaurun/notification.go:229:3: this value of err is never used (SA4006)
```
It is a bug. I fixed it.