### PR TITLE
fix infinite loop if channel is close

### DIFF
--- a/cmd/gaurun/gaurun.go
+++ b/cmd/gaurun/gaurun.go
@@ -179,13 +179,10 @@ func main() {
 }
 
 func signalHandler(ch <-chan os.Signal, sighupFn func()) {
-	for {
-		select {
-		case sig := <-ch:
-			switch sig {
-			case syscall.SIGHUP:
-				sighupFn()
-			}
+	for sig := range ch {
+		switch sig {
+		case syscall.SIGHUP:
+			sighupFn()
 		}
 	}
 }


### PR DESCRIPTION
if signal channel is close, it causes infinite loop.
Now, it is not close but I fixed it
